### PR TITLE
Clean up repository documentation and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Local build outputs and temporary files
+*.tmp
+*.log

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ This project was developed as part of an academic engineering assignment. While 
 
 **Lead Developer:** Isaac "Zac" Adjei  
 **Team:** NeoPixel Innovators 
-**Project Repository:**   
+**Project Repository:** https://github.com/zaccesss/neopixel-led-cube  
 **Dependencies:** Adafruit NeoPixel Library
 
 ### 11.3 Credits
@@ -315,13 +315,9 @@ neopixel-led-cube/
 │
 ├── docs/
 │   ├── README.md
-│   ├── code-screenshot-1.png
-│   ├── code-screenshot-2.png
 │   ├── finance-report.xlsx
 │   ├── gantt-chart.xlsx
 │   ├── market-analysis.docx
-│   ├── neopixel-demo.mp4
-│   ├── neopixel-description.mp4
 │   ├── notes-and-drafts.docx
 │   ├── presentation-final.pptx
 │   ├── software-portfolio.docx
@@ -332,12 +328,12 @@ neopixel-led-cube/
 │   └── hardware-overview.pptx
 │
 ├── media/
+│   ├── Gallery.md
 │   ├── README.md
 │   ├── code-screenshot-1.png
 │   ├── code-screenshot-2.png
 │   ├── cube-build-layer-top-view-1.jpeg
-│   ├── cube-build-layer-top-view-2.jpeg
-│   ├── cube-build-top-view-1.jpeg
+│   ├── cube-build-lit-view-1.jpeg
 │   ├── cube-enclosure-final-setup-1.jpeg
 │   ├── cube-frame-complete-angle-1.jpeg
 │   ├── cube-lit-full-bright-front-1.jpeg
@@ -351,11 +347,9 @@ neopixel-led-cube/
 │
 └── software/
     ├── README.md
-    ├── software-portfolio.docx
-    ├── software-portfolio-v2.docx
-    └── neopixel-cube/
+    └── neopixel_cube/
         ├── README.md
-        └── neopixel-cube.ino
+        └── neopixel_cube.ino
 ```
 
 </details>

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,9 @@ The spreadsheet provides detailed financial tracking for the project, demonstrat
 4. Testing and refinement (debugging, optimization)
 5. Documentation (technical writing, media production)
 
-### hardware-overview.pptx
+### Related hardware-overview.pptx
+
+**Location:** `../hardware/hardware-overview.pptx`
 
 **Purpose:** Visual presentation of hardware design and assembly
 
@@ -108,6 +110,10 @@ Similar to software-portfolio.docx with improvements to:
 **Differences from Version 1:**
 Version 2 represents a refinement of the original portfolio with enhanced readability and more precise technical language while maintaining comprehensive coverage of all software components.
 
+## Related Media Files
+
+The following supporting media files are stored in `../media/` rather than this documentation directory.
+
 ### code-screenshot-1.png and code-screenshot-2.png
 
 **Purpose:** High-resolution code capture for documentation
@@ -119,8 +125,6 @@ Visual representation of key code sections, particularly:
 - Header and initialization code
 - Main loop structure
 - Pattern function implementations
-
-## Media Files
 
 ### neopixel-demo.mp4
 
@@ -186,11 +190,11 @@ The planning documents (gantt-chart, finance-report) demonstrate:
 | Market Analysis | .docx | Microsoft Word or compatible |
 | Finance Report | .xlsx | Microsoft Excel or compatible |
 | Gantt Chart | .xlsx | Microsoft Excel or compatible |
-| Hardware Overview | .pptx | Microsoft PowerPoint or compatible |
+| Hardware Overview | .pptx | Microsoft PowerPoint or compatible; stored in `hardware/` |
 | Notes and Drafts | .docx | Microsoft Word or compatible |
 | Software Portfolio | .docx | Microsoft Word or compatible |
-| Code Screenshots | .png | Image viewer |
-| Demo Videos | .mp4 | Video player |
+| Code Screenshots | .png | Image viewer; stored in `media/` |
+| Demo Videos | .mp4 | Video player; stored in `media/` |
 
 ## Document Revision History
 

--- a/media/Gallery.md
+++ b/media/Gallery.md
@@ -15,21 +15,11 @@
 
   <tr>
     <td width="45%">
-      <b>Cube Layer Assembly – Alternate View</b><br>
-      Additional angle demonstrating vertical alignment and wiring consistency across the 4×4 grid.
+      <b>Cube Build Test – Lit View</b><br>
+      Lighting test during the build process to verify LED continuity and data flow.
     </td>
     <td>
-      <img src="cube-build-layer-top-view-2.jpeg" width="100%">
-    </td>
-  </tr>
-
-  <tr>
-    <td width="45%">
-      <b>Top View of Completed Layer</b><br>
-      A completed LED layer before stacking, ensuring continuity and correct data flow direction.
-    </td>
-    <td>
-      <img src="cube-build-top-view-1.jpeg" width="100%">
+      <img src="cube-build-lit-view-1.jpeg" width="100%">
     </td>
   </tr>
 

--- a/media/README.md
+++ b/media/README.md
@@ -12,11 +12,35 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 **Usage:** Hardware documentation, construction reference  
 **Resolution:** High-resolution photograph suitable for detailed examination
 
+#### cube-build-lit-view-1.jpeg
+**Description:** LED cube lit during build testing  
+**Purpose:** Verifies LED continuity, data flow and early pattern output  
+**Usage:** Build process documentation and testing reference  
+**Resolution:** High-resolution photograph suitable for project documentation
+
+#### cube-frame-complete-angle-1.jpeg
+**Description:** Completed cube frame from an angled view  
+**Purpose:** Documents the completed layered structure before final enclosure integration  
+**Usage:** Hardware documentation and construction reference  
+**Resolution:** High-resolution photograph suitable for detailed examination
+
 #### cube-lit-full-bright-front-1.jpeg
 **Description:** Completed LED cube illuminated at full brightness  
 **Purpose:** Showcases final appearance and light output  
 **Usage:** Project showcase, documentation header  
 **Resolution:** High-resolution photograph with vibrant color capture
+
+#### cube-lit-full-bright-front-2.jpeg
+**Description:** Alternate front view of the completed cube at full brightness  
+**Purpose:** Provides an additional validation angle for brightness and alignment  
+**Usage:** Project showcase and gallery documentation  
+**Resolution:** High-resolution photograph with vibrant color capture
+
+#### cube-enclosure-final-setup-1.jpeg
+**Description:** Complete assembled project in enclosure  
+**Purpose:** Documents final integrated system  
+**Usage:** Project showcase, completion reference  
+**Resolution:** High-resolution photograph showing complete assembly
 
 #### power-circuit-capacitor-closeup-1.jpeg
 **Description:** Detail view of power supply filtering circuit  
@@ -24,17 +48,23 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 **Usage:** Hardware assembly reference, circuit verification  
 **Resolution:** Close-up photograph showing component detail
 
+#### power-circuit-connected-to-cube-1.jpeg
+**Description:** Power distribution wiring connected to the cube  
+**Purpose:** Documents LED power delivery and wiring organization  
+**Usage:** Hardware assembly reference and power wiring verification  
+**Resolution:** High-resolution photograph showing wiring detail
+
 #### enclosure-arduino-breadboard-top-1.jpeg
 **Description:** Top view of internal component layout  
 **Purpose:** Shows Arduino, breadboard and wiring organization  
 **Usage:** Assembly reference, cable management guide  
 **Resolution:** High-resolution photograph of internal configuration
 
-#### cube-enclosure-final-setup-1.jpeg
-**Description:** Complete assembled project in enclosure  
-**Purpose:** Documents final integrated system  
-**Usage:** Project showcase, completion reference  
-**Resolution:** High-resolution photograph showing complete assembly
+#### enclosure-arduino-breadboard-top-2.jpeg
+**Description:** Secondary top view of the internal electronics  
+**Purpose:** Highlights cable routing and component placement from another angle  
+**Usage:** Assembly reference and enclosure documentation  
+**Resolution:** High-resolution photograph of internal configuration
 
 ### Videos
 

--- a/software/README.md
+++ b/software/README.md
@@ -10,9 +10,9 @@ The software architecture is designed around a state machine model that continuo
 ```
 software/
 ├── README.md (this file)
-└── neopixel-cube/
+└── neopixel_cube/
     ├── README.md
-    └── neopixel-cube.ino
+    └── neopixel_cube.ino
 ```
 
 ## Core Functionality
@@ -101,7 +101,7 @@ Sketch → Include Library → Manage Libraries → Search "Adafruit NeoPixel"
 
 ### Steps
 
-1. Open `neopixel-cube.ino` in Arduino IDE
+1. Open `neopixel_cube.ino` in Arduino IDE
 2. Select board: Tools → Board → Arduino Uno
 3. Select port: Tools → Port → [appropriate COM port]
 4. Verify code: Sketch → Verify/Compile
@@ -159,4 +159,4 @@ Change the buzzer pin or adjust the duration in the `beep()` function.
 - Test LDR functionality with Serial Monitor output
 - Check mapping range in code
 
-For additional details on specific functions and implementation, refer to the inline comments in `neopixel-cube.ino`.
+For additional details on specific functions and implementation, refer to the inline comments in `neopixel_cube.ino`.

--- a/software/neopixel_cube/README.md
+++ b/software/neopixel_cube/README.md
@@ -4,7 +4,7 @@ This directory contains the Arduino sketch that controls the 4×4×4 NeoPixel LE
 
 ## File Contents
 
-- `neopixel-cube.ino` – Main Arduino sketch
+- `neopixel_cube.ino` – Main Arduino sketch
 
 ## Pin Configuration
 


### PR DESCRIPTION
closes #1

Summary:
- Adds a root .gitignore for local IDE and temporary files.
- Corrects README directory trees and Arduino sketch path references.
- Replaces missing gallery image references with existing media and expands the media inventory.
- Clarifies related hardware/media locations in docs README.

Review notes:
- Checked stale filename references with ripgrep.
- Checked Gallery.md image src values against files in media/.