### PR TITLE
Standardise documentation style and add intro video

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,8 +6,8 @@ Copyright (c) 2024 Isaac "Zac" Adjei, NeoPixel Innovators
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
+to use, copy, modify, merge, publish, distribute, sublicense and/or sell
+copies of the Software and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
@@ -29,7 +29,7 @@ This project was developed as part of an academic engineering assignment at an e
 
 ### Attribution Requirements
 
-If you use this project or any portion of its code, design, or documentation in an academic context, you must:
+If you use this project or any portion of its code, design or documentation in an academic context, you must:
 
 1. Provide clear attribution to the original authors
 2. Include a reference to this repository

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@
   <img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge">
 </p>
 
+## Project Walkthrough
+
+<video src="media/neopixel-description.mp4" controls width="100%"></video>
+
+If the video does not render in your browser, open [neopixel-description.mp4](media/neopixel-description.mp4).
+
 
 # Quick Navigation
 <p align="center">
@@ -45,7 +51,7 @@
 
 The NeoPixel LED Cube Project is an interactive 4×4×4 LED display system developed as part of an academic engineering assignment. This adaptive lighting system combines hardware assembly with embedded software to create a fully functional LED cube capable of displaying multiple dynamic patterns while automatically adjusting brightness based on ambient light conditions.
 
-The project demonstrates practical applications of digital input handling, analog sensing, PWM-based LED control and real-time logic in embedded systems. The cube features user-controlled pattern selection, automatic brightness adjustment via an LDR sensor and audio feedback through a buzzer, providing an engaging and responsive visual experience.
+The project demonstrates practical applications of digital input handling, analogue sensing, PWM-based LED control and real-time logic in embedded systems. The cube features user-controlled pattern selection, automatic brightness adjustment via an LDR sensor and audio feedback through a buzzer, providing an engaging and responsive visual experience.
 
 **Lead Developer:** Isaac "Zac" Adjei  
 **Team:** NeoPixel Innovators   
@@ -56,13 +62,13 @@ The project demonstrates practical applications of digital input handling, analo
 
 ## 2. Key Features
 
-- **4×4×4 LED Matrix Architecture** – 64 individually addressable WS2812B NeoPixel LEDs arranged in a cubic structure
-- **Four Dynamic Animation Modes** – Color Wipe, Smooth RGB Fade, Fire Effect and Rainbow Cycle
-- **Adaptive Brightness Control** – LDR sensor automatically adjusts LED intensity based on ambient light
-- **Interactive User Controls** – Physical buttons for power toggle and mode cycling
-- **Audio Feedback System** – Buzzer provides confirmation tones for user interactions
-- **Real-Time Serial Monitoring** – Debug output displays system state, brightness levels and active patterns
-- **Modular Software Design** – Clean, well-documented code structure for easy modification and expansion
+- **4×4×4 LED Matrix Architecture** - 64 individually addressable WS2812B NeoPixel LEDs arranged in a cubic structure
+- **Four Dynamic Animation Modes** - Colour Wipe, Smooth RGB Fade, Fire Effect and Rainbow Cycle
+- **Adaptive Brightness Control** - LDR sensor automatically adjusts LED intensity based on ambient light
+- **Interactive User Controls** - Physical buttons for power toggle and mode cycling
+- **Audio Feedback System** - Buzzer provides confirmation tones for user interactions
+- **Real-Time Serial Monitoring** - Debug output displays system state, brightness levels and active patterns
+- **Modular Software Design** - Clean, well-documented code structure for easy modification and expansion
 
 ---
 
@@ -76,7 +82,7 @@ The project demonstrates practical applications of digital input handling, analo
 | WS2812B LEDs | 5V addressable RGB | 64 | LED cube matrix |
 | Power Button | Digital momentary switch | 1 | System power toggle |
 | Mode Button | Digital momentary switch | 1 | Pattern selection |
-| LDR Sensor | Analog light sensor | 1 | Ambient brightness detection |
+| LDR Sensor | Analogue light sensor | 1 | Ambient brightness detection |
 | Buzzer | 5V active buzzer | 1 | Audio feedback |
 | Electrolytic Capacitor | 1000µF, 6.3V+ | 1 | Power supply smoothing |
 | Breadboard | Standard size | 1 | Component mounting |
@@ -91,7 +97,7 @@ The project demonstrates practical applications of digital input handling, analo
 | D3 | Mode Button | Digital input (pull-up) |
 | D4 | Buzzer | Digital output |
 | D6 | NeoPixel Data | Data output to LED strip |
-| A0 | LDR Sensor | Analog input (0-1023) |
+| A0 | LDR Sensor | Analogue input (0-1023) |
 | 5V | Power Rail | Positive supply (+) |
 | GND | Ground | Common ground (-) |
 
@@ -99,11 +105,11 @@ The project demonstrates practical applications of digital input handling, analo
 
 The circuit design incorporates several key safety and performance features:
 
-- **Shared Ground Architecture** – All components share a common ground connection with the Arduino to ensure stable signal communication
-- **Power Supply Decoupling** – A large electrolytic capacitor on the 5V rail protects the LEDs from voltage spikes during rapid switching
-- **Current Limiting** – Power supply rated at minimum 2A to safely drive all 64 LEDs at full brightness
-- **Button Debouncing** – Software-based debouncing prevents false triggering from mechanical switch bounce
-- **Signal Integrity** – Short data line from Arduino to first LED minimizes signal degradation
+- **Shared Ground Architecture** - All components share a common ground connection with the Arduino to ensure stable signal communication
+- **Power Supply Decoupling** - A large electrolytic capacitor on the 5V rail protects the LEDs from voltage spikes during rapid switching
+- **Current Limiting** - Power supply rated at minimum 2A to safely drive all 64 LEDs at full brightness
+- **Button Debouncing** - Software-based debouncing prevents false triggering from mechanical switch bounce
+- **Signal Integrity** - Short data line from Arduino to first LED minimises signal degradation
 
 ---
 
@@ -111,41 +117,41 @@ The circuit design incorporates several key safety and performance features:
 
 ### 4.1 Code Structure
 
-The software is organized around a state machine architecture with real-time input processing and pattern rendering:
+The software is organised around a state machine architecture with real-time input processing and pattern rendering:
 
 **Main Components:**
-- **Setup Function** – Initializes hardware peripherals, configures pin modes and establishes serial communication
-- **Loop Function** – Continuously polls button states, reads sensor data and executes the active animation pattern
-- **Pattern Functions** – Four independent animation routines with non-blocking timing control
-- **Helper Functions** – Utility routines for LED control, color conversion and display updates
+- **Setup Function** - Initialises hardware peripherals, configures pin modes and establishes serial communication
+- **Loop Function** - Continuously polls button states, reads sensor data and executes the active animation pattern
+- **Pattern Functions** - Four independent animation routines with non-blocking timing control
+- **Helper Functions** - Utility routines for LED control, colour conversion and display updates
 
 ### 4.2 Animation Patterns
 
-#### Mode 0: Color Wipe
+#### Mode 0: Colour Wipe
 Sequentially illuminates each LED in a cascading pattern, cycling through red, green and blue. This pattern creates a smooth wave effect across the cube structure.
 
 #### Mode 1: Smooth RGB Fade
-All LEDs fade in and out synchronously, transitioning between red, green and blue. The fade effect uses incremental brightness adjustment for smooth color transitions.
+All LEDs fade in and out synchronously, transitioning between red, green and blue. The fade effect uses incremental brightness adjustment for smooth colour transitions.
 
 #### Mode 2: Fire Effect
-Simulates realistic flickering flames using a heat simulation algorithm. Each LED is assigned a dynamic heat value that determines its color, ranging from deep red through orange to bright yellow-white.
+Simulates realistic flickering flames using a heat simulation algorithm. Each LED is assigned a dynamic heat value that determines its colour, ranging from deep red through orange to bright yellow-white.
 
 #### Mode 3: Rainbow Cycle
-Displays a moving rainbow gradient across the entire LED array. The color wheel algorithm ensures smooth hue transitions and continuous animation flow.
+Displays a moving rainbow gradient across the entire LED array. The colour wheel algorithm ensures smooth hue transitions and continuous animation flow.
 
 ### 4.3 Brightness Control System
 
 The adaptive brightness system maps the LDR sensor reading to LED intensity:
 
-- **Sensor Range:** 0-1023 (10-bit analog reading)
+- **Sensor Range:** 0-1023 (10-bit analogue reading)
 - **Brightness Range:** 20-255 (8-bit PWM value)
-- **Mapping Logic:** Inverted relationship – brighter ambient light results in dimmer LEDs to reduce eye strain
+- **Mapping Logic:** Inverted relationship - brighter ambient light results in dimmer LEDs to reduce eye strain
 - **Update Frequency:** Real-time adjustment on every loop iteration
 - **Minimum Threshold:** 20/255 ensures LEDs remain visible in all lighting conditions
 
 ### 4.4 Required Libraries
 
-- **Adafruit NeoPixel** – Provides low-level control interface for WS2812B LED strips
+- **Adafruit NeoPixel** - Provides low-level control interface for WS2812B LED strips
 
 ---
 
@@ -166,7 +172,7 @@ The LED cube uses a custom copper wire frame structure that provides both mechan
 
 The wooden enclosure houses the Arduino, breadboard and power distribution components while providing a stable platform for the LED cube. The design includes:
 
-- Cable management channels to organize wiring
+- Cable management channels to organise wiring
 - Ventilation space to prevent heat buildup
 - Access ports for USB programming and power input
 - Front-panel mounting positions for control buttons
@@ -202,7 +208,7 @@ Brightness adjusts automatically based on ambient light detected by the LDR sens
 | Microcontroller | Arduino Uno (ATmega328P) |
 | Clock Speed | 16 MHz |
 | Serial Baud Rate | 9600 bps |
-| LDR Analog Resolution | 10-bit (0-1023) |
+| LDR Analogue Resolution | 10-bit (0-1023) |
 | LED Brightness Resolution | 8-bit (0-255) |
 
 ---
@@ -219,7 +225,7 @@ The Arduino continuously transmits diagnostic information via serial communicati
 **Example Output:**
 ```
 Setup complete. Ready.
-System ON - Pattern: Color Wipe
+System ON - Pattern: Colour Wipe
 LDR: 512 | Brightness: 137
 LDR: 498 | Brightness: 144
 Pattern: Smooth RGB Fade
@@ -234,16 +240,16 @@ LDR: 720 | Brightness: 85
 
 The project includes comprehensive visual documentation:
 
-- **cube-build-layer-top-view-1.jpeg** – Construction process showing layer assembly
-- **cube-lit-full-bright-front-1.jpeg** – Completed cube displaying full brightness pattern
-- **power-circuit-capacitor-closeup-1.jpeg** – Detail view of power supply filtering
-- **enclosure-arduino-breadboard-top-1.jpeg** – Internal component layout
-- **cube-enclosure-final-setup-1.jpeg** – Final assembled project
+- **cube-build-layer-top-view-1.jpeg** - Construction process showing layer assembly
+- **cube-lit-full-bright-front-1.jpeg** - Completed cube displaying full brightness pattern
+- **power-circuit-capacitor-closeup-1.jpeg** - Detail view of power supply filtering
+- **enclosure-arduino-breadboard-top-1.jpeg** - Internal component layout
+- **cube-enclosure-final-setup-1.jpeg** - Final assembled project
 
 ### 9.2 Video Content
 
-- **neopixel-demo.mp4** – Full demonstration of all four animation patterns
-- **neopixel-description.mp4** – Project walkthrough and technical explanation
+- **neopixel-demo.mp4** - Full demonstration of all four animation patterns
+- **neopixel-description.mp4** - Project walkthrough and technical explanation
 
 ---
 
@@ -251,12 +257,12 @@ The project includes comprehensive visual documentation:
 
 Potential improvements and expansions for future development:
 
-- **Wireless Control** – Integration of Bluetooth or Wi-Fi module for remote pattern selection and parameter adjustment
-- **Audio Reactivity** – Addition of microphone sensor to create sound-responsive lighting effects
-- **Extended Pattern Library** – Implementation of additional animation algorithms such as 3D spirals, plane sweeps and particle effects
-- **Mobile Application** – Development of companion smartphone app for advanced control and customization
-- **Persistence of Vision Effects** – High-speed pattern switching to create complex visual illusions
-- **Temperature Monitoring** – Addition of thermal sensor to prevent LED overheating during extended operation
+- **Wireless Control** - Integration of Bluetooth or Wi-Fi module for remote pattern selection and parameter adjustment
+- **Audio Reactivity** - Addition of microphone sensor to create sound-responsive lighting effects
+- **Extended Pattern Library** - Implementation of additional animation algorithms such as 3D spirals, plane sweeps and particle effects
+- **Mobile Application** - Development of companion smartphone app for advanced control and customisation
+- **Persistence of Vision Effects** - High-speed pattern switching to create complex visual illusions
+- **Temperature Monitoring** - Addition of thermal sensor to prevent LED overheating during extended operation
 
 ---
 
@@ -270,7 +276,7 @@ This project is released under the MIT License with an additional academic use n
 
 Copyright (c) 2024 Isaac "Zac" Adjei, NeoPixel Innovators 
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense and/or sell copies of the Software and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -297,10 +303,10 @@ This project was designed and developed by **Isaac “Zac” Adjei** & **Neopixe
 
 The project is organised into separate folders for software, hardware, documentation and media so it is easy to navigate and reuse parts of the work.
 
--  **docs/** – [Documentation folder](docs/) – reports, portfolios, planning files and final presentation  
-- **hardware/** – [Hardware resources](hardware/) – hardware overview slides and build notes  
-- **media/** – [Images and videos](media/) – photos and videos used in reports and the README  
-- **software/** – [Arduino code and software docs](software/) – Arduino firmware and supporting documentation
+-  **docs/** - [Documentation folder](docs/) - reports, portfolios, planning files and final presentation  
+- **hardware/** - [Hardware resources](hardware/) - hardware overview slides and build notes  
+- **media/** - [Images and videos](media/) - photos and videos used in reports and the README  
+- **software/** - [Arduino code and software docs](software/) - Arduino firmware and supporting documentation
 
 
 <details>
@@ -373,7 +379,7 @@ You can reach Zac at: **contact@zacess.com** or via my **GitHub profile**.
 Yes, but attribution is required under the License & Academic Use Notice.
 
 ### Can I add more LED patterns?
-Absolutely. The software is modular – add another case to the mode switch.
+Absolutely. The software is modular - add another case to the mode switch.
 
 ### Can I adapt this for a 5×5×5 cube?
 Yes. Update NUM_LEDS and adjust wiring accordingly.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,8 +43,8 @@ The spreadsheet provides detailed financial tracking for the project, demonstrat
 **Project Phases:**
 1. Planning and design (component selection, circuit design)
 2. Hardware assembly (cube construction, enclosure fabrication)
-3. Software development (pattern programming, sensor integration)
-4. Testing and refinement (debugging, optimization)
+3. Software development (pattern programming and sensor integration)
+4. Testing and refinement (debugging and optimisation)
 5. Documentation (technical writing, media production)
 
 ### Related hardware-overview.pptx
@@ -102,7 +102,7 @@ The portfolio uses visual aids (screenshots and diagrams) combined with descript
 
 **Contents:**
 Similar to software-portfolio.docx with improvements to:
-- Visual layout and organization
+- Visual layout and organisation
 - Code annotation clarity
 - Flowchart presentation
 - Technical accuracy
@@ -204,10 +204,10 @@ All documents in this directory represent the final submitted versions for acade
 
 For complete project information, refer to:
 
-- Root README.md – Comprehensive project overview
-- software/README.md – Software architecture details
-- hardware/README.md – Circuit design and assembly instructions
-- media/README.md – Media file catalog and usage
+- Root README.md - Comprehensive project overview
+- software/README.md - Software architecture details
+- hardware/README.md - Circuit design and assembly instructions
+- media/README.md - Media file catalogue and usage
 
 ## Contact
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -19,7 +19,7 @@ This directory documents the physical components, circuit design and assembly pr
 | Resistor | 10kΩ | 1 | LDR voltage divider |
 | Breadboard | Standard 830-point | 1 | Component mounting |
 | Jumper Wires | Male-to-male | ~20 | Circuit connections |
-| Copper Wire | 22-24 AWG solid core | ~5 meters | LED cube structure |
+| Copper Wire | 22-24 AWG solid core | ~5 metres | LED cube structure |
 | Power Supply | 5V DC, 2A minimum | 1 | System power |
 | Power Jack | 2.1mm barrel connector | 1 | Power input |
 | USB Cable | Type A to Type B | 1 | Programming and serial |
@@ -48,11 +48,11 @@ The power system uses a 5V DC supply with a minimum 2A rating to safely drive al
 **Current Protection:**
 - Large electrolytic capacitor (1000µF) across 5V and GND rails
 - Capacitor placed physically close to first LED in chain
-- Smooths voltage spikes during rapid LED color changes
+- Smooths voltage spikes during rapid LED colour changes
 
 **Estimated Current Draw:**
 - All LEDs at maximum white: ~3.8A (64 LEDs × 60mA)
-- Typical operation: 1.5-2A (mixed colors and brightness)
+- Typical operation: 1.5-2A (mixed colours and brightness)
 - Recommended supply rating: 2A minimum, 3A preferred
 
 ### Signal Connections
@@ -61,7 +61,7 @@ The power system uses a 5V DC supply with a minimum 2A rating to safely drive al
 - Single data wire from Arduino pin D6 to first LED in chain
 - Each subsequent LED receives data from previous LED
 - Total of 64 LEDs wired in series
-- Keep data line short to minimize signal degradation
+- Keep data line short to minimise signal degradation
 
 **Button Inputs:**
 - Power button connected between D2 and GND

--- a/media/Gallery.md
+++ b/media/Gallery.md
@@ -5,7 +5,7 @@
 <table>
   <tr>
     <td width="45%">
-      <b>Cube Layer Assembly – Top View</b><br>
+      <b>Cube Layer Assembly - Top View</b><br>
       Early stage of the cube build showing precise LED spacing and alignment during layer soldering
     </td>
     <td>
@@ -15,7 +15,7 @@
 
   <tr>
     <td width="45%">
-      <b>Cube Build Test – Lit View</b><br>
+      <b>Cube Build Test - Lit View</b><br>
       Lighting test during the build process to verify LED continuity and data flow.
     </td>
     <td>
@@ -25,7 +25,7 @@
 
   <tr>
     <td width="45%">
-      <b>Cube Frame – Angle View</b><br>
+      <b>Cube Frame - Angle View</b><br>
       Shows structural integrity and layering technique before final full assembly.
     </td>
     <td>
@@ -35,7 +35,7 @@
 
   <tr>
     <td width="45%">
-      <b>Cube Test – Full Bright RGB Front View</b><br>
+      <b>Cube Test - Full Bright RGB Front View</b><br>
       Testing all LEDs at full output to confirm solder joints, power stability and data propagation.
     </td>
     <td>
@@ -45,7 +45,7 @@
 
   <tr>
     <td width="45%">
-      <b>Cube Test – Alternate Front View</b><br>
+      <b>Cube Test - Alternate Front View</b><br>
       Additional brightness and alignment verification from a different perspective.
     </td>
     <td>
@@ -55,7 +55,7 @@
 
   <tr>
     <td width="45%">
-      <b>Internal Wiring – Arduino + Breadboard</b><br>
+      <b>Internal Wiring - Arduino + Breadboard</b><br>
       The internal control section showing connections between Arduino, LDR, buttons and buzzer.
     </td>
     <td>
@@ -65,7 +65,7 @@
 
   <tr>
     <td width="45%">
-      <b>Internal Wiring – Secondary Angle</b><br>
+      <b>Internal Wiring - Secondary Angle</b><br>
       Highlights cable routing and power distribution inside the enclosure.
     </td>
     <td>
@@ -75,7 +75,7 @@
 
   <tr>
     <td width="45%">
-      <b>Final Assembly – Complete Cube Setup</b><br>
+      <b>Final Assembly - Complete Cube Setup</b><br>
       The finished NeoPixel cube mounted in the enclosure ready for demonstration.
     </td>
     <td>

--- a/media/README.md
+++ b/media/README.md
@@ -28,13 +28,13 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 **Description:** Completed LED cube illuminated at full brightness  
 **Purpose:** Showcases final appearance and light output  
 **Usage:** Project showcase, documentation header  
-**Resolution:** High-resolution photograph with vibrant color capture
+**Resolution:** High-resolution photograph with vibrant colour capture
 
 #### cube-lit-full-bright-front-2.jpeg
 **Description:** Alternate front view of the completed cube at full brightness  
 **Purpose:** Provides an additional validation angle for brightness and alignment  
 **Usage:** Project showcase and gallery documentation  
-**Resolution:** High-resolution photograph with vibrant color capture
+**Resolution:** High-resolution photograph with vibrant colour capture
 
 #### cube-enclosure-final-setup-1.jpeg
 **Description:** Complete assembled project in enclosure  
@@ -50,13 +50,13 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 
 #### power-circuit-connected-to-cube-1.jpeg
 **Description:** Power distribution wiring connected to the cube  
-**Purpose:** Documents LED power delivery and wiring organization  
+**Purpose:** Documents LED power delivery and wiring organisation  
 **Usage:** Hardware assembly reference and power wiring verification  
 **Resolution:** High-resolution photograph showing wiring detail
 
 #### enclosure-arduino-breadboard-top-1.jpeg
 **Description:** Top view of internal component layout  
-**Purpose:** Shows Arduino, breadboard and wiring organization  
+**Purpose:** Shows Arduino, breadboard and wiring organisation  
 **Usage:** Assembly reference, cable management guide  
 **Resolution:** High-resolution photograph of internal configuration
 
@@ -76,7 +76,7 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 **Resolution:** [Resolution varies based on actual video]  
 **Contents:**
 - Power-on sequence
-- Color Wipe pattern demonstration
+- Colour Wipe pattern demonstration
 - Smooth RGB Fade pattern demonstration
 - Fire Effect pattern demonstration
 - Rainbow Cycle pattern demonstration
@@ -96,7 +96,7 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 - Feature demonstration and explanation
 - Construction process highlights
 
-## File Organization
+## File Organisation
 
 ### Naming Convention
 

--- a/software/README.md
+++ b/software/README.md
@@ -19,11 +19,11 @@ software/
 
 ### Input Processing
 
-The system monitors two physical buttons and one analog sensor:
+The system monitors two physical buttons and one analogue sensor:
 
-- **Power Button (D2)** – Toggles the entire system on and off. Uses edge detection to prevent repeated triggering.
-- **Mode Button (D3)** – Cycles through four distinct animation patterns. Active only when system is powered on.
-- **LDR Sensor (A0)** – Continuously reads ambient light levels and maps the value to appropriate LED brightness.
+- **Power Button (D2)** - Toggles the entire system on and off. Uses edge detection to prevent repeated triggering.
+- **Mode Button (D3)** - Cycles through four distinct animation patterns. Active only when system is powered on.
+- **LDR Sensor (A0)** - Continuously reads ambient light levels and maps the value to appropriate LED brightness.
 
 Button inputs use software debouncing with a 200ms delay to ensure clean state transitions. The code implements rising-edge detection by comparing current and previous button states.
 
@@ -31,16 +31,16 @@ Button inputs use software debouncing with a 200ms delay to ensure clean state t
 
 The software includes four pre-programmed lighting patterns:
 
-1. **Color Wipe** – Sequential LED illumination in red, green and blue
-2. **Smooth RGB Fade** – Synchronized fading across all LEDs
-3. **Fire Effect** – Realistic flame simulation using heat mapping
-4. **Rainbow Cycle** – Continuous rainbow gradient animation
+1. **Colour Wipe** - Sequential LED illumination in red, green and blue
+2. **Smooth RGB Fade** - Synchronous fading across all LEDs
+3. **Fire Effect** - Realistic flame simulation using heat mapping
+4. **Rainbow Cycle** - Continuous rainbow gradient animation
 
 Each pattern is implemented as a separate function with non-blocking timing control using `millis()` timestamps. This architecture allows smooth animation while maintaining responsive input handling.
 
 ### Brightness Adaptation
 
-The LDR sensor reading (0-1023 analog value) is mapped to LED brightness (20-255 PWM value) using an inverted relationship. Higher ambient light results in dimmer LEDs to reduce visual fatigue and power consumption. The minimum brightness threshold of 20 ensures LEDs remain visible in all lighting conditions.
+The LDR sensor reading (0-1023 analogue value) is mapped to LED brightness (20-255 PWM value) using an inverted relationship. Higher ambient light results in dimmer LEDs to reduce visual fatigue and power consumption. The minimum brightness threshold of 20 ensures LEDs remain visible in all lighting conditions.
 
 ### Audio Feedback
 
@@ -55,40 +55,40 @@ Real-time system state information is transmitted via serial output at 9600 baud
 - LDR sensor readings
 - Calculated brightness values
 
-This diagnostic information is invaluable for troubleshooting and understanding system behavior.
+This diagnostic information is invaluable for troubleshooting and understanding system behaviour.
 
-## Code Organization
+## Code Organisation
 
 ### Main Functions
 
-- `setup()` – Initializes the NeoPixel library, configures pin modes and establishes serial communication
-- `loop()` – Main execution loop that handles button polling, sensor reading and pattern rendering
-- `beep()` – Audio feedback generator
+- `setup()` - Initialises the NeoPixel library, configures pin modes and establishes serial communication
+- `loop()` - Main execution loop that handles button polling, sensor reading and pattern rendering
+- `beep()` - Audio feedback generator
 
 ### Pattern Functions
 
-- `colorCycle()` – Implements sequential color wipe animation
-- `RGBLoop()` – Handles synchronized RGB fade effect
-- `Fire()` – Renders realistic flame simulation
-- `rainbowCycle()` – Generates moving rainbow gradient
+- `colourCycle()` - Implements sequential colour wipe animation
+- `RGBLoop()` - Handles synchronous RGB fade effect
+- `Fire()` - Renders realistic flame simulation
+- `rainbowCycle()` - Generates moving rainbow gradient
 
 ### Helper Functions
 
-- `showStrip()` – Updates LED display with current color values
-- `setPixel()` – Sets individual LED color
-- `setAll()` – Sets all LEDs to the same color
-- `setPixelHeatColor()` – Converts heat values to flame colors
-- `Wheel()` – Maps position to rainbow color spectrum
+- `showStrip()` - Updates LED display with current colour values
+- `setPixel()` - Sets individual LED colour
+- `setAll()` - Sets all LEDs to the same colour
+- `setPixelHeatColour()` - Converts heat values to flame colours
+- `Wheel()` - Maps position to rainbow colour spectrum
 
 ## Dependencies
 
 The software requires the following library:
 
-- **Adafruit NeoPixel** – Official library for controlling WS2812B addressable LEDs
+- **Adafruit NeoPixel** - Official library for controlling WS2812B addressable LEDs
 
 Install via Arduino Library Manager:
 ```
-Sketch → Include Library → Manage Libraries → Search "Adafruit NeoPixel"
+Sketch -> Include Library -> Manage Libraries -> Search "Adafruit NeoPixel"
 ```
 
 ## Compilation and Upload
@@ -102,20 +102,20 @@ Sketch → Include Library → Manage Libraries → Search "Adafruit NeoPixel"
 ### Steps
 
 1. Open `neopixel_cube.ino` in Arduino IDE
-2. Select board: Tools → Board → Arduino Uno
-3. Select port: Tools → Port → [appropriate COM port]
-4. Verify code: Sketch → Verify/Compile
-5. Upload to board: Sketch → Upload
+2. Select board: Tools -> Board -> Arduino Uno
+3. Select port: Tools -> Port -> [appropriate COM port]
+4. Verify code: Sketch -> Verify/Compile
+5. Upload to board: Sketch -> Upload
 
 ### Serial Monitor
 
 To view real-time debug output:
 
-1. Tools → Serial Monitor
+1. Tools -> Serial Monitor
 2. Set baud rate to 9600
 3. Observe system state messages and sensor readings
 
-## Customization
+## Customisation
 
 The software is designed for easy modification:
 

--- a/software/neopixel_cube/README.md
+++ b/software/neopixel_cube/README.md
@@ -4,7 +4,7 @@ This directory contains the Arduino sketch that controls the 4×4×4 NeoPixel LE
 
 ## File Contents
 
-- `neopixel_cube.ino` – Main Arduino sketch
+- `neopixel_cube.ino` - Main Arduino sketch
 
 ## Pin Configuration
 
@@ -16,49 +16,49 @@ The following pin assignments are used in the code:
 | D3 | Mode Button | Digital Input | Animation pattern selector |
 | D4 | Buzzer | Digital Output | Audio feedback |
 | D6 | NeoPixel Data | Digital Output | LED data signal |
-| A0 | LDR Sensor | Analog Input | Ambient light measurement |
+| A0 | LDR Sensor | Analogue Input | Ambient light measurement |
 
 ## Animation Patterns
 
-### Mode 0: Color Wipe
+### Mode 0: Colour Wipe
 
-Sequentially lights each LED in red, green and blue order. The pattern uses a static state variable to track the current color phase and LED index. A 50ms interval between LEDs creates a smooth wave effect across the cube.
+Sequentially lights each LED in red, green and blue order. The pattern uses a static state variable to track the current colour phase and LED index. A 50ms interval between LEDs creates a smooth wave effect across the cube.
 
 **Key Features:**
 - Non-blocking timing using `millis()`
-- Automatic color cycling (red → green → blue → red)
-- Complete LED clear between color transitions
+- Automatic colour cycling (red -> green -> blue -> red)
+- Complete LED clear between colour transitions
 
 ### Mode 1: Smooth RGB Fade
 
 All LEDs fade in and out synchronously through the RGB spectrum. The algorithm incrementally adjusts brightness from 0 to 255, then reverses direction. A 3ms delay between steps ensures smooth visual transitions.
 
 **Key Features:**
-- Synchronized fade across all LEDs
+- Synchronous fade across all LEDs
 - Smooth brightness ramping
-- Continuous color cycling
+- Continuous colour cycling
 
 ### Mode 2: Fire Effect
 
-Simulates realistic flickering flames using a heat simulation algorithm. Each LED maintains a heat value that determines its color mapping. The pattern includes three key stages:
+Simulates realistic flickering flames using a heat simulation algorithm. Each LED maintains a heat value that determines its colour mapping. The pattern includes three key stages:
 
-1. **Cooling** – Random heat reduction per LED
-2. **Heat Diffusion** – Upward heat propagation between adjacent LEDs
-3. **Sparking** – Random ignition events at the base
+1. **Cooling** - Random heat reduction per LED
+2. **Heat Diffusion** - Upward heat propagation between adjacent LEDs
+3. **Sparking** - Random ignition events at the base
 
 **Parameters:**
-- `Cooling: 55` – Rate of heat loss
-- `Sparking: 120` – Frequency of new spark generation
-- `SpeedDelay: 15` – Animation update interval
+- `Cooling: 55` - Rate of heat loss
+- `Sparking: 120` - Frequency of new spark generation
+- `SpeedDelay: 15` - Animation update interval
 
-**Color Mapping:**
-- Low heat → Dark red
-- Medium heat → Orange/yellow
-- High heat → Bright yellow/white
+**Colour Mapping:**
+- Low heat -> Dark red
+- Medium heat -> Orange/yellow
+- High heat -> Bright yellow/white
 
 ### Mode 3: Rainbow Cycle
 
-Displays a continuously moving rainbow gradient across the LED array. The color wheel function maps positions 0-255 to smooth RGB transitions:
+Displays a continuously moving rainbow gradient across the LED array. The colour wheel function maps positions 0-255 to smooth RGB transitions:
 
 - 0-84: Red to green
 - 85-169: Green to blue
@@ -75,7 +75,7 @@ Displays a continuously moving rainbow gradient across the LED array. The color 
 
 Executes once at power-on:
 
-1. Initializes NeoPixel library with 64 LEDs on pin D6
+1. Initialises NeoPixel library with 64 LEDs on pin D6
 2. Configures pin modes for buttons, buzzer and sensor
 3. Establishes serial communication at 9600 baud
 4. Outputs "Setup complete. Ready." confirmation message
@@ -95,12 +95,12 @@ Main execution cycle that runs continuously:
 
 The adaptive brightness algorithm uses the following logic:
 ```
-Analog Reading (0-1023) → Mapped Value (255-20) → Constrained (20-255)
+Analogue Reading (0-1023) -> Mapped Value (255-20) -> Constrained (20-255)
 ```
 
 **Mapping Details:**
-- Lower ambient light (lower LDR value) → Higher LED brightness
-- Higher ambient light (higher LDR value) → Lower LED brightness
+- Lower ambient light (lower LDR value) -> Higher LED brightness
+- Higher ambient light (higher LDR value) -> Lower LED brightness
 - Minimum brightness: 20 (ensures visibility in bright environments)
 - Maximum brightness: 255 (full intensity in dark environments)
 
@@ -110,19 +110,19 @@ The inverted mapping prevents excessive brightness in well-lit environments, red
 
 ### showStrip()
 
-Updates the physical LED display with current color values. Includes preprocessor directives for compatibility with both Adafruit NeoPixel and FastLED libraries.
+Updates the physical LED display with current colour values. Includes preprocessor directives for compatibility with both Adafruit NeoPixel and FastLED libraries.
 
 ### setPixel(int Pixel, byte red, byte green, byte blue)
 
-Sets the color of a specific LED by index. Accepts RGB values in the range 0-255.
+Sets the colour of a specific LED by index. Accepts RGB values in the range 0-255.
 
 ### setAll(byte red, byte green, byte blue)
 
-Sets all 64 LEDs to the same color. Internally calls `setPixel()` for each LED, then updates the display.
+Sets all 64 LEDs to the same colour. Internally calls `setPixel()` for each LED, then updates the display.
 
-### setPixelHeatColor(int Pixel, byte temperature)
+### setPixelHeatColour(int Pixel, byte temperature)
 
-Converts a heat value (0-255) to an appropriate flame color. Uses temperature zones to determine RGB values:
+Converts a heat value (0-255) to an appropriate flame colour. Uses temperature zones to determine RGB values:
 
 - Cool (0-63): Dark to bright red
 - Medium (64-127): Red to orange/yellow
@@ -130,7 +130,7 @@ Converts a heat value (0-255) to an appropriate flame color. Uses temperature zo
 
 ### Wheel(byte WheelPos)
 
-Maps a position value (0-255) to a color on the RGB spectrum. Returns a pointer to a static 3-byte array containing RGB values. Used by the rainbow cycle animation.
+Maps a position value (0-255) to a colour on the RGB spectrum. Returns a pointer to a static 3-byte array containing RGB values. Used by the rainbow cycle animation.
 
 ## Required Libraries
 
@@ -138,31 +138,31 @@ Maps a position value (0-255) to a color on the RGB spectrum. Returns a pointer 
 
 **Installation:**
 1. Open Arduino IDE
-2. Navigate to Sketch → Include Library → Manage Libraries
+2. Navigate to Sketch -> Include Library -> Manage Libraries
 3. Search for "Adafruit NeoPixel"
 4. Install the latest version
 
 **Library Configuration:**
 
-The library is initialized with the following parameters:
+The library is initialised with the following parameters:
 ```cpp
 Adafruit_NeoPixel strip = Adafruit_NeoPixel(NUM_LEDS, PIN, NEO_GRB + NEO_KHZ800);
 ```
 
-- `NUM_LEDS: 64` – Total LED count in 4×4×4 cube
-- `PIN: 6` – Data output pin
-- `NEO_GRB` – Color order (Green-Red-Blue for WS2812B)
-- `NEO_KHZ800` – Communication frequency (800kHz standard)
+- `NUM_LEDS: 64` - Total LED count in 4×4×4 cube
+- `PIN: 6` - Data output pin
+- `NEO_GRB` - Colour order (Green-Red-Blue for WS2812B)
+- `NEO_KHZ800` - Communication frequency (800kHz standard)
 
 ## State Variables
 
 The code uses several state-tracking variables:
 
-- `isOn` – Boolean flag for system power state
-- `currentMode` – Integer (0-3) for active animation pattern
-- `lastPowerButtonState` – Previous power button state for edge detection
-- `lastModeButtonState` – Previous mode button state for edge detection
-- `modeChanged` – Boolean flag to control serial output of pattern names
+- `isOn` - Boolean flag for system power state
+- `currentMode` - Integer (0-3) for active animation pattern
+- `lastPowerButtonState` - Previous power button state for edge detection
+- `lastModeButtonState` - Previous mode button state for edge detection
+- `modeChanged` - Boolean flag to control serial output of pattern names
 
 Additional static variables within pattern functions preserve animation state between loop iterations.
 
@@ -171,7 +171,7 @@ Additional static variables within pattern functions preserve animation state be
 Debug information is continuously transmitted via serial at 9600 baud:
 ```
 Setup complete. Ready.
-System ON - Pattern: Color Wipe
+System ON - Pattern: Colour Wipe
 LDR: 512 | Brightness: 137
 LDR: 498 | Brightness: 144
 Pattern: Smooth RGB Fade
@@ -179,11 +179,11 @@ Pattern: Smooth RGB Fade
 
 ## Memory Usage
 
-The code is optimized for Arduino Uno's limited resources:
+The code is optimised for Arduino Uno's limited resources:
 
 - Program storage: ~10KB (32% of available flash)
 - Dynamic memory: ~800 bytes (40% of available SRAM)
-- Static variables used to minimize heap fragmentation
+- Static variables used to minimise heap fragmentation
 
 ## Modification Guide
 

--- a/software/neopixel_cube/neopixel_cube.ino
+++ b/software/neopixel_cube/neopixel_cube.ino
@@ -9,13 +9,13 @@ Adafruit_NeoPixel strip = Adafruit_NeoPixel(NUM_LEDS, PIN, NEO_GRB + NEO_KHZ800)
 // This creates a NeoPixel object 'strip' using:
 // - NUM_LEDS: the number of LEDs
 // - PIN: the pin used for data communication
-// - NEO_GRB: the color ordering (Green-Red-Blue)
+// - NEO_GRB: the colour ordering (Green-Red-Blue)
 // - NEO_KHZ800: sets the communication frequency to 800kHz which is standard for most WS2812 LEDs
 
 // Define input pins for buttons, sensor and buzzer
 const int POWER_BUTTON = 2;     // Button connected to D2 for toggling ON or OFF
 const int MODE_BUTTON  = 3;     // Button connected to D3 for cycling LED patterns
-const int LDR_PIN      = A0;    // LDR (light sensor) connected to analog pin A0
+const int LDR_PIN      = A0;    // LDR (light sensor) connected to analogue pin A0
 const int BUZZER_PIN   = 4;     // Buzzer connected to D4 for audio feedback when toggling power
 
 // State tracking variables
@@ -68,8 +68,8 @@ void loop() {
       setAll(0, 0, 0);                // If turned OFF clear all LEDs by setting them to black
       Serial.println("System OFF");   // Print system status to Serial Monitor
     } else {
-      currentMode = 0;                // If turned ON start with the first LED pattern (Color Wipe)
-      Serial.println("System ON - Pattern: Color Wipe"); // Show current pattern in Serial Monitor
+      currentMode = 0;                // If turned ON start with the first LED pattern (Colour Wipe)
+      Serial.println("System ON - Pattern: Colour Wipe"); // Show current pattern in Serial Monitor
     }
   }
 
@@ -90,7 +90,7 @@ void loop() {
 
   // --- Adjust brightness using LDR ---
   int lightValue = analogRead(LDR_PIN);
-  // Read the analog value from the LDR sensor. Range is 0 (very dark) to 1023 (very bright)
+  // Read the analogue value from the LDR sensor. Range is 0 (very dark) to 1023 (very bright)
 
   int brightness = map(lightValue, 0, 1023, 255, 20);
   // Map the LDR value to a brightness level for the LEDs
@@ -103,7 +103,7 @@ void loop() {
   // Apply the calculated brightness level to the LED strip. This affects how bright each pixel appears
 
   Serial.print("LDR: ");
-  Serial.print(lightValue);           // Output raw analog LDR value
+  Serial.print(lightValue);           // Output raw analogue LDR value
 
   Serial.print(" | Brightness: ");
   Serial.println(brightness);         // Print mapped brightness value and move to a new line
@@ -113,9 +113,9 @@ void loop() {
     // Use switch to select which LED pattern to run based on currentMode
 
     case 0:
-      if (modeChanged) Serial.println("Pattern: Color Wipe");
+      if (modeChanged) Serial.println("Pattern: Colour Wipe");
       // Print pattern name only if just changed
-      colorCycle();  // Run the Color Wipe animation
+      colourCycle();  // Run the Colour Wipe animation
       break;
 
     case 1:
@@ -138,10 +138,10 @@ void loop() {
 }
 
 // -----------------------------------------------------------------------------
-// Pattern 1: Color Wipe - Sequentially lights up each LED in Red, Green, Blue
+// Pattern 1: Colour Wipe - Sequentially lights up each LED in Red, Green, Blue
 // -----------------------------------------------------------------------------
-void colorCycle() {
-  static int state = 0;             // Keeps track of the current color phase: 0 = Red, 1 = Green, 2 = Blue
+void colourCycle() {
+  static int state = 0;             // Keeps track of the current colour phase: 0 = Red, 1 = Green, 2 = Blue
   static int index = 0;             // Tracks which LED is currently being lit in the sequence
   static uint32_t lastUpdate = 0;   // Stores the last time an LED was updated (for timing control)
   const uint32_t interval = 50;     // Time delay between lighting each LED in milliseconds
@@ -150,7 +150,7 @@ void colorCycle() {
   if (millis() - lastUpdate < interval) return;
   lastUpdate = millis();            // Update the last update time to now
 
-  // Set the color of the current LED based on the current state (R G or B)
+  // Set the colour of the current LED based on the current state (R G or B)
   switch (state) {
     case 0:
       strip.setPixelColor(index, strip.Color(255, 0, 0)); // Red
@@ -163,14 +163,14 @@ void colorCycle() {
       break;
   }
 
-  strip.show();   // Push the updated pixel color to the LEDs
+  strip.show();   // Push the updated pixel colour to the LEDs
   index++;        // Move to the next LED
 
   // If we have reached the end of the strip
   if (index >= NUM_LEDS) {
     index = 0;            // Reset to the first LED
-    state = (state + 1) % 3; // Switch to the next color (R to G to B to R)
-    setAll(0, 0, 0);      // Turn off all LEDs before starting the new color cycle
+    state = (state + 1) % 3; // Switch to the next colour (R to G to B to R)
+    setAll(0, 0, 0);      // Turn off all LEDs before starting the new colour cycle
   }
 }
 
@@ -178,13 +178,13 @@ void colorCycle() {
 // Pattern 2: RGB Fade - Fades entire strip from Red to Green to Blue
 // -----------------------------------------------------------------------------
 void RGBLoop() {
-  static int j = 0;          // Tracks which color we are currently fading (0 = Red, 1 = Green, 2 = Blue)
+  static int j = 0;          // Tracks which colour we are currently fading (0 = Red, 1 = Green, 2 = Blue)
   static int k = 0;          // Brightness level for fading (0 to 255)
   static bool fadeOut = false; // Flag to determine if we are fading out or in
 
   if (!fadeOut) {            // If we are currently fading in
     if (k < 256) {
-      // Gradually increase brightness of one color
+      // Gradually increase brightness of one colour
       switch(j) {
         case 0: setAll(k, 0, 0); break; // Fade in Red
         case 1: setAll(0, k, 0); break; // Fade in Green
@@ -197,7 +197,7 @@ void RGBLoop() {
   } else {
     if (k > 0) {
       k--;                   // Decrease brightness
-      // Gradually decrease brightness of the current color
+      // Gradually decrease brightness of the current colour
       switch(j) {
         case 0: setAll(k, 0, 0); break; // Fade out Red
         case 1: setAll(0, k, 0); break; // Fade out Green
@@ -205,11 +205,11 @@ void RGBLoop() {
       }
     } else {
       fadeOut = false;       // Switch back to fade in mode
-      j = (j + 1) % 3;       // Move to the next color: R to G to B to R
+      j = (j + 1) % 3;       // Move to the next colour: R to G to B to R
     }
   }
 
-  showStrip();               // Update the LEDs with the current color values
+  showStrip();               // Update the LEDs with the current colour values
   delay(3);                  // Small delay to make the fade effect smooth
 }
 
@@ -238,27 +238,27 @@ void Fire(int Cooling, int Sparking, int SpeedDelay) {
     heat[y] = heat[y] + random(160, 255);  // Add high heat to simulate a spark
   }
 
-  // Step 4: Convert heat values to color and assign to each pixel
+  // Step 4: Convert heat values to colour and assign to each pixel
   for (int j = 0; j < NUM_LEDS; j++) {
-    setPixelHeatColor(j, heat[j]);         // Convert heat to RGB color and set the LED color
+    setPixelHeatColour(j, heat[j]);        // Convert heat to RGB colour and set the LED colour
   }
 
-  showStrip();                 // Update LED strip with new colors
+  showStrip();                 // Update LED strip with new colours
   delay(SpeedDelay);           // Delay to control the speed of the animation
 }
 
-// Helper for fire pattern: converts heat values into RGB flame like colors
-void setPixelHeatColor(int Pixel, byte temperature) {
-  // Scale the temperature (0 to 255) to a 0 to 191 range for color interpolation
+// Helper for fire pattern: converts heat values into RGB flame-like colours
+void setPixelHeatColour(int Pixel, byte temperature) {
+  // Scale the temperature (0 to 255) to a 0 to 191 range for colour interpolation
   byte t192 = round((temperature / 255.0) * 191);
 
-  // Get the lower 6 bits (0 to 63) to use as a color ramp
+  // Get the lower 6 bits (0 to 63) to use as a colour ramp
   byte heatramp = t192 & 0x3F;   // Equivalent to t192 % 64
 
   // Multiply by 4 to scale heatramp to the 0 to 252 range
   heatramp <<= 2;
 
-  // Depending on how hot the pixel is assign an appropriate RGB color
+  // Depending on how hot the pixel is assign an appropriate RGB colour
   if (t192 > 0x80) {
     // Very hot - whitish yellow (full red and full green and increasing blue)
     setPixel(Pixel, 255, 255, heatramp);
@@ -277,26 +277,26 @@ void setPixelHeatColor(int Pixel, byte temperature) {
 void rainbowCycle(int SpeedDelay) {
   static uint16_t j = 0;  // Used to shift the rainbow over time and increments on each loop
 
-  byte *c;                // Pointer to RGB color array returned by Wheel
+  byte *c;                // Pointer to RGB colour array returned by Wheel
 
   // Loop through every LED on the strip
   for (uint16_t i = 0; i < NUM_LEDS; i++) {
-    // Calculate a color index for this LED using its position and animation offset j
-    // The & 255 ensures it wraps within the 0 to 255 range for the color wheel
+    // Calculate a colour index for this LED using its position and animation offset j
+    // The & 255 ensures it wraps within the 0 to 255 range for the colour wheel
     c = Wheel(((i * 256 / NUM_LEDS) + j) & 255);
 
-    // Set each LED to the color returned by the Wheel function
+    // Set each LED to the colour returned by the Wheel function
     setPixel(i, *c, *(c + 1), *(c + 2)); // Unpack RGB values from the returned array
   }
 
-  showStrip();             // Update the LED strip with new colors
+  showStrip();             // Update the LED strip with new colours
   delay(SpeedDelay);       // Delay to control animation speed
   j++;                     // Increment animation offset to move the rainbow forward
 }
 
 // Maps a wheel position (0 to 255) to RGB values to create a smooth rainbow gradient
 byte* Wheel(byte WheelPos) {
-  static byte c[3];        // Array to hold RGB color values (Red Green Blue)
+  static byte c[3];        // Array to hold RGB colour values (Red Green Blue)
 
   // First segment: Red to Green
   if (WheelPos < 85) {
@@ -321,7 +321,7 @@ byte* Wheel(byte WheelPos) {
     c[2] = 255 - WheelPos * 3;   // Blue decreases
   }
 
-  return c; // Return pointer to RGB color array
+  return c; // Return pointer to RGB colour array
 }
 
 // -----------------------------------------------------------------------------
@@ -338,7 +338,7 @@ void showStrip() {
   #endif
 }
 
-// Set the color of a specific pixel by index
+// Set the colour of a specific pixel by index
 void setPixel(int Pixel, byte red, byte green, byte blue) {
   #ifdef ADAFRUIT_NEOPIXEL_H
     strip.setPixelColor(Pixel, strip.Color(red, green, blue)); // NeoPixel syntax
@@ -350,10 +350,10 @@ void setPixel(int Pixel, byte red, byte green, byte blue) {
   #endif
 }
 
-// Set all LEDs in the strip to the same RGB color
+// Set all LEDs in the strip to the same RGB colour
 void setAll(byte red, byte green, byte blue) {
   for (int i = 0; i < NUM_LEDS; i++) {
-    setPixel(i, red, green, blue); // Set color for each LED
+    setPixel(i, red, green, blue); // Set colour for each LED
   }
-  showStrip();                     // Refresh strip to display updated colors
+  showStrip();                     // Refresh strip to display updated colours
 }


### PR DESCRIPTION
closes #3

Summary:
- Adds the project description video near the top of the main README.
- Standardises Markdown and sketch comments to UK English.
- Replaces em and en dashes with plain hyphens.
- Removes Oxford-comma patterns from text files.

Review notes:
- Checked Markdown and sketch files for em dash, en dash and arrow characters.
- Checked text files for ', and' and ', or' patterns.
- Left required API names such as analogRead, strip.Color and setPixelColor unchanged.