### PR TITLE
docs: embed demo video in README using GitHub video player

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@
 
 ## Project Walkthrough
 
-<video src="media/neopixel-description.mp4" controls width="100%"></video>
-
-If the video does not render in your browser, open [neopixel-description.mp4](media/neopixel-description.mp4).
+https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
 
 
 # Quick Navigation


### PR DESCRIPTION
## Summary
I replaced the local <video> tag in the README with a bare GitHub user-attachments URL so my demo video renders as an embedded player when visitors view the repo on GitHub.

## Changes
- Removed the <video> HTML tag and fallback link from the Project Walkthrough section
- Added the user-attachments URL which GitHub auto-renders as a native video player

## How to test
1. View the README on GitHub
2. Confirm the video player appears in the Project Walkthrough section
3. Press play and confirm the video plays inline

## Related issue
closes #5