### PR TITLE
docs: restructure readme and expand docs navigation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,41 @@
+# Frequently Asked Questions
+
+## Can I use this project for coursework?
+
+Yes. I require attribution under [LICENSE.md](LICENSE.md) and the academic use notice.
+
+## Where can I see all build photos?
+
+Open the full gallery: [media/Gallery.md](media/Gallery.md).
+
+## Where is the Arduino code?
+
+The main sketch is here: [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino).
+
+## Where is the software explanation?
+
+See [software/README.md](software/README.md) for architecture and function details.
+
+## Where is the hardware documentation?
+
+See [hardware/README.md](hardware/README.md) for components and wiring details.
+
+## Can I adapt this for a 5x5x5 cube?
+
+Yes. Update the LED count, revise power planning and adjust pattern logic for the larger matrix.
+
+## Can I add more LED patterns?
+
+Yes. Add a new pattern function and include it in the mode switch in the main loop.
+
+## How do I ask questions that are not covered here?
+
+Please open an issue in this repository with your setup details and question.
+
+## Can I contact you directly?
+
+Yes. Email me at contact@zacess.com.
+
+## Last Updated
+
+May 2026

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 # LICENSE
+
 ### MIT License
 
 Copyright (c) 2024 Isaac "Zac" Adjei, NeoPixel Innovators
@@ -37,10 +38,11 @@ If you use this project or any portion of its code, design or documentation in a
 4. Not claim this work as your own original creation
 
 ### Recommended Citation Format
+
 ```
-Adjei, I. "Z." (2024). NeoPixel LED Cube Project: Adaptive LED Cube System 
-with Sensor Driven Brightness and Multi Pattern Rendering. 
-NeoPixel Innovators 
+Adjei, I. "Z." (2024). NeoPixel LED Cube Project: Adaptive LED Cube System
+with Sensor Driven Brightness and Multi Pattern Rendering.
+NeoPixel Innovators
 ```
 
 ### Educational Use
@@ -62,4 +64,6 @@ While the MIT License permits commercial use, users should be aware that some ha
 
 **Project Team:** NeoPixel Innovators
 **Lead Developer:** Isaac "Zac" Adjei  
-**Project Year:** 2025
+**Project Year:** 2026
+
+**Last Reviewed:** May 2026

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-<p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&height=110&section=header&text=NeoPixel%20LED%20Cube%20Project&fontSize=34&fontAlignY=32&fontColor=ffffff&animation=fadeIn" />
-</p>
-
 # Project Contact & Links
+
 <p align="center">
   <a href="https://linktr.ee/zaccess">
     <img src="https://img.shields.io/badge/Linktree-zaccess-1de9b6?style=for-the-badge&logo=linktree&logoColor=white">
@@ -13,6 +10,9 @@
   <a href="mailto:offices.isaac@gmail.com">
     <img src="https://img.shields.io/badge/Email-Contact-ff6f61?style=for-the-badge&logo=gmail&logoColor=white">
   </a>
+  <a href="https://isaacadjei.me">
+    <img src="https://img.shields.io/badge/Portfolio-isaacadjei.me-111111?style=for-the-badge&logo=firefox&logoColor=white">
+  </a>
   
 </p>
 <p align="center">
@@ -21,10 +21,12 @@
 
 ## Project Walkthrough
 
+<p align="center">
 https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
-
+</p>
 
 # Quick Navigation
+
 <p align="center">
   🔎 •  
   <a href="#1-project-overview">Overview</a> •
@@ -37,10 +39,10 @@ https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
   <a href="#8-serial-monitor-output">Serial output</a> •
   <a href="#9-demonstration-media">Media</a> •
   <a href="#10-future-enhancements">Future</a> •
-  <a href="#11-license-credits-and-attribution">License and credits</a> •
+  <a href="#11-license-and-supporting-links">License and links</a> •
   <a href="#12-repository-structure">Repo structure</a> •
   <a href="#contact-and-support">Contact</a> •
-  <a href="#faq">FAQ</a>
+  <a href="FAQ.md">FAQ</a>
 </p>
 
 ---
@@ -52,7 +54,7 @@ The NeoPixel LED Cube Project is an interactive 4×4×4 LED display system devel
 The project demonstrates practical applications of digital input handling, analogue sensing, PWM-based LED control and real-time logic in embedded systems. The cube features user-controlled pattern selection, automatic brightness adjustment via an LDR sensor and audio feedback through a buzzer, providing an engaging and responsive visual experience.
 
 **Lead Developer:** Isaac "Zac" Adjei  
-**Team:** NeoPixel Innovators   
+**Team:** NeoPixel Innovators  
 **Platform:** Arduino Uno  
 **LED Count:** 64 WS2812B addressable LEDs
 
@@ -74,30 +76,30 @@ The project demonstrates practical applications of digital input handling, analo
 
 ### 3.1 Component List
 
-| Component | Specification | Quantity | Purpose |
-|-----------|---------------|----------|---------|
-| Arduino Uno | ATmega328P | 1 | Main microcontroller |
-| WS2812B LEDs | 5V addressable RGB | 64 | LED cube matrix |
-| Power Button | Digital momentary switch | 1 | System power toggle |
-| Mode Button | Digital momentary switch | 1 | Pattern selection |
-| LDR Sensor | Analogue light sensor | 1 | Ambient brightness detection |
-| Buzzer | 5V active buzzer | 1 | Audio feedback |
-| Electrolytic Capacitor | 1000µF, 6.3V+ | 1 | Power supply smoothing |
-| Breadboard | Standard size | 1 | Component mounting |
-| Power Supply | 5V, ≥2A | 1 | System power |
-| Enclosure | Custom wooden box | 1 | Housing and protection |
+| Component              | Specification            | Quantity | Purpose                      |
+| ---------------------- | ------------------------ | -------- | ---------------------------- |
+| Arduino Uno            | ATmega328P               | 1        | Main microcontroller         |
+| WS2812B LEDs           | 5V addressable RGB       | 64       | LED cube matrix              |
+| Power Button           | Digital momentary switch | 1        | System power toggle          |
+| Mode Button            | Digital momentary switch | 1        | Pattern selection            |
+| LDR Sensor             | Analogue light sensor    | 1        | Ambient brightness detection |
+| Buzzer                 | 5V active buzzer         | 1        | Audio feedback               |
+| Electrolytic Capacitor | 1000µF, 6.3V+            | 1        | Power supply smoothing       |
+| Breadboard             | Standard size            | 1        | Component mounting           |
+| Power Supply           | 5V, ≥2A                  | 1        | System power                 |
+| Enclosure              | Custom wooden box        | 1        | Housing and protection       |
 
 ### 3.2 Pin Configuration
 
-| Arduino Pin | Component | Function |
-|-------------|-----------|----------|
-| D2 | Power Button | Digital input (pull-up) |
-| D3 | Mode Button | Digital input (pull-up) |
-| D4 | Buzzer | Digital output |
-| D6 | NeoPixel Data | Data output to LED strip |
-| A0 | LDR Sensor | Analogue input (0-1023) |
-| 5V | Power Rail | Positive supply (+) |
-| GND | Ground | Common ground (-) |
+| Arduino Pin | Component     | Function                 |
+| ----------- | ------------- | ------------------------ |
+| D2          | Power Button  | Digital input (pull-up)  |
+| D3          | Mode Button   | Digital input (pull-up)  |
+| D4          | Buzzer        | Digital output           |
+| D6          | NeoPixel Data | Data output to LED strip |
+| A0          | LDR Sensor    | Analogue input (0-1023)  |
+| 5V          | Power Rail    | Positive supply (+)      |
+| GND         | Ground        | Common ground (-)        |
 
 ### 3.3 Circuit Design
 
@@ -118,6 +120,7 @@ The circuit design incorporates several key safety and performance features:
 The software is organised around a state machine architecture with real-time input processing and pattern rendering:
 
 **Main Components:**
+
 - **Setup Function** - Initialises hardware peripherals, configures pin modes and establishes serial communication
 - **Loop Function** - Continuously polls button states, reads sensor data and executes the active animation pattern
 - **Pattern Functions** - Four independent animation routines with non-blocking timing control
@@ -126,15 +129,19 @@ The software is organised around a state machine architecture with real-time inp
 ### 4.2 Animation Patterns
 
 #### Mode 0: Colour Wipe
+
 Sequentially illuminates each LED in a cascading pattern, cycling through red, green and blue. This pattern creates a smooth wave effect across the cube structure.
 
 #### Mode 1: Smooth RGB Fade
+
 All LEDs fade in and out synchronously, transitioning between red, green and blue. The fade effect uses incremental brightness adjustment for smooth colour transitions.
 
 #### Mode 2: Fire Effect
+
 Simulates realistic flickering flames using a heat simulation algorithm. Each LED is assigned a dynamic heat value that determines its colour, ranging from deep red through orange to bright yellow-white.
 
 #### Mode 3: Rainbow Cycle
+
 Displays a moving rainbow gradient across the entire LED array. The colour wheel algorithm ensures smooth hue transitions and continuous animation flow.
 
 ### 4.3 Brightness Control System
@@ -160,6 +167,7 @@ The adaptive brightness system maps the LDR sensor reading to LED intensity:
 The LED cube uses a custom copper wire frame structure that provides both mechanical support and electrical connections. The 4×4×4 matrix is built layer by layer, with each layer soldered into place before proceeding to the next.
 
 **Construction Process:**
+
 1. Created a jig to ensure precise LED spacing and alignment
 2. Bent and cut copper wire segments to form the structural framework
 3. Soldered LEDs in series, maintaining proper data line polarity
@@ -195,19 +203,19 @@ Brightness adjusts automatically based on ambient light detected by the LDR sens
 
 ## 7. Technical Specifications
 
-| Parameter | Value |
-|-----------|-------|
-| LED Type | WS2812B (addressable RGB) |
-| Total LED Count | 64 |
-| Matrix Configuration | 4×4×4 cube |
-| Operating Voltage | 5V DC |
-| Maximum Current Draw | ~3.8A (all LEDs at full white) |
-| Recommended Power Supply | 5V, ≥2A |
-| Microcontroller | Arduino Uno (ATmega328P) |
-| Clock Speed | 16 MHz |
-| Serial Baud Rate | 9600 bps |
-| LDR Analogue Resolution | 10-bit (0-1023) |
-| LED Brightness Resolution | 8-bit (0-255) |
+| Parameter                 | Value                          |
+| ------------------------- | ------------------------------ |
+| LED Type                  | WS2812B (addressable RGB)      |
+| Total LED Count           | 64                             |
+| Matrix Configuration      | 4×4×4 cube                     |
+| Operating Voltage         | 5V DC                          |
+| Maximum Current Draw      | ~3.8A (all LEDs at full white) |
+| Recommended Power Supply  | 5V, ≥2A                        |
+| Microcontroller           | Arduino Uno (ATmega328P)       |
+| Clock Speed               | 16 MHz                         |
+| Serial Baud Rate          | 9600 bps                       |
+| LDR Analogue Resolution   | 10-bit (0-1023)                |
+| LED Brightness Resolution | 8-bit (0-255)                  |
 
 ---
 
@@ -221,6 +229,7 @@ The Arduino continuously transmits diagnostic information via serial communicati
 - Calculated brightness values
 
 **Example Output:**
+
 ```
 Setup complete. Ready.
 System ON - Pattern: Colour Wipe
@@ -249,6 +258,10 @@ The project includes comprehensive visual documentation:
 - **neopixel-demo.mp4** - Full demonstration of all four animation patterns
 - **neopixel-description.mp4** - Project walkthrough and technical explanation
 
+For build photos and image walkthroughs, open [media/Gallery.md](media/Gallery.md).
+
+For Arduino source code, open [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino).
+
 ---
 
 ## 10. Future Enhancements
@@ -264,36 +277,18 @@ Potential improvements and expansions for future development:
 
 ---
 
-## 11. License, Credits and Attribution
+## 11. License and Supporting Links
 
-### 11.1 License
-
-This project is released under the MIT License with an additional academic use notice.
-
-**MIT License**
-
-Copyright (c) 2024 Isaac "Zac" Adjei, NeoPixel Innovators 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense and/or sell copies of the Software and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-**Academic Use Notice**
-
-This project was developed as part of an academic engineering assignment. While the code and design are open source, users incorporating this work into their own academic projects should provide appropriate attribution and ensure compliance with their institution's academic integrity policies.
-
-### 11.2 Attribution
+- License text: [LICENSE.md](LICENSE.md)
+- Expanded FAQ: [FAQ.md](FAQ.md)
+- Full image gallery: [media/Gallery.md](media/Gallery.md)
+- Software overview: [software/README.md](software/README.md)
+- Arduino sketch: [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino)
 
 **Lead Developer:** Isaac "Zac" Adjei  
-**Team:** NeoPixel Innovators 
+**Team:** NeoPixel Innovators  
 **Project Repository:** https://github.com/zaccesss/neopixel-led-cube  
 **Dependencies:** Adafruit NeoPixel Library
-
-### 11.3 Credits
-
-This project was designed and developed by **Isaac “Zac” Adjei** & **Neopixel Innovators** 
 
 ---
 
@@ -301,11 +296,10 @@ This project was designed and developed by **Isaac “Zac” Adjei** & **Neopixe
 
 The project is organised into separate folders for software, hardware, documentation and media so it is easy to navigate and reuse parts of the work.
 
--  **docs/** - [Documentation folder](docs/) - reports, portfolios, planning files and final presentation  
-- **hardware/** - [Hardware resources](hardware/) - hardware overview slides and build notes  
-- **media/** - [Images and videos](media/) - photos and videos used in reports and the README  
+- **docs/** - [Documentation folder](docs/) - reports, portfolios, planning files and final presentation
+- **hardware/** - [Hardware resources](hardware/) - hardware overview slides and build notes
+- **media/** - [Images and videos](media/) - photos and videos used in reports and the README
 - **software/** - [Arduino code and software docs](software/) - Arduino firmware and supporting documentation
-
 
 <details>
 <summary><b>Click to expand full directory tree</b></summary>
@@ -362,26 +356,11 @@ neopixel-led-cube/
 
 ## Contact and Support
 
-For questions, suggestions or collaboration opportunities related to this project, please open an issue in the repository or contact the development team through the provided channels.
+For questions, suggestions or collaboration opportunities related to this project, I recommend opening an issue in this repository first.
 
-You can reach Zac at: **contact@zacess.com** or via my **GitHub profile**.
+You can also contact me directly at **contact@zacess.com**.
 
 **Project Status:** Completed  
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 ---
-
-## FAQ
-
-### Can I use this project for my coursework?
-Yes, but attribution is required under the License & Academic Use Notice.
-
-### Can I add more LED patterns?
-Absolutely. The software is modular - add another case to the mode switch.
-
-### Can I adapt this for a 5×5×5 cube?
-Yes. Update NUM_LEDS and adjust wiring accordingly.
-
----
-
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 This directory contains all project documentation including market analysis, financial reports, project management materials and technical portfolios. These documents provide context and supporting information for the NeoPixel LED Cube Project.
 
+For quick navigation to visuals and media, see [../media/Gallery.md](../media/Gallery.md).
+
 ## Document Overview
 
 ### market-analysis.docx
@@ -9,6 +11,7 @@ This directory contains all project documentation including market analysis, fin
 **Purpose:** Competitive market analysis of similar LED cube products
 
 **Contents:**
+
 - Comparison of competing commercial LED cube kits
 - Price points and feature sets
 - Analysis of available products on Amazon and AliExpress
@@ -22,6 +25,7 @@ The market analysis identified three primary competing products ranging from £2
 **Purpose:** Project budget tracking and financial documentation
 
 **Contents:**
+
 - Component costs and sourcing information
 - Budget allocation across hardware, materials and tools
 - Cost comparison with commercial alternatives
@@ -35,12 +39,14 @@ The spreadsheet provides detailed financial tracking for the project, demonstrat
 **Purpose:** Project timeline and task management
 
 **Contents:**
+
 - Project phases and milestones
 - Task dependencies and critical path
 - Resource allocation timeline
 - Progress tracking against planned schedule
 
 **Project Phases:**
+
 1. Planning and design (component selection, circuit design)
 2. Hardware assembly (cube construction, enclosure fabrication)
 3. Software development (pattern programming and sensor integration)
@@ -54,6 +60,7 @@ The spreadsheet provides detailed financial tracking for the project, demonstrat
 **Purpose:** Visual presentation of hardware design and assembly
 
 **Contents:**
+
 - Component specifications and rationale
 - Circuit diagrams and wiring schematics
 - Assembly process photography
@@ -67,6 +74,7 @@ This presentation serves as a technical overview for academic evaluation and pro
 **Purpose:** Early planning documents and development notes
 
 **Contents:**
+
 - Initial project requirements (essential and recommended features)
 - Hardware selection criteria
 - Early code snippets and algorithm concepts
@@ -80,6 +88,7 @@ This document preserves the project's evolution from initial concept to final im
 **Purpose:** Comprehensive code documentation and software architecture overview
 
 **Contents:**
+
 - Annotated code screenshots with detailed explanations
 - Function-by-function breakdown of software logic
 - Software flowchart illustrating program execution
@@ -87,6 +96,7 @@ This document preserves the project's evolution from initial concept to final im
 - Input handling and sensor integration details
 
 **Key Sections:**
+
 - Setup and configuration
 - Main loop structure
 - Lighting pattern implementations
@@ -102,6 +112,7 @@ The portfolio uses visual aids (screenshots and diagrams) combined with descript
 
 **Contents:**
 Similar to software-portfolio.docx with improvements to:
+
 - Visual layout and organisation
 - Code annotation clarity
 - Flowchart presentation
@@ -122,6 +133,7 @@ The following supporting media files are stored in `../media/` rather than this 
 
 **Content:**
 Visual representation of key code sections, particularly:
+
 - Header and initialization code
 - Main loop structure
 - Pattern function implementations
@@ -131,12 +143,14 @@ Visual representation of key code sections, particularly:
 **Purpose:** Video demonstration of all four animation patterns
 
 **Contents:**
+
 - Complete walkthrough of system functionality
 - All four patterns displayed in sequence
 - Brightness adjustment demonstration
 - User interaction with buttons
 
 **Technical Specifications:**
+
 - Format: MP4 (H.264)
 - Suitable for presentation and documentation
 - Shows cube from multiple angles
@@ -146,6 +160,7 @@ Visual representation of key code sections, particularly:
 **Purpose:** Technical explanation video
 
 **Contents:**
+
 - Project overview and objectives
 - Hardware component tour
 - Software architecture explanation
@@ -185,16 +200,16 @@ The planning documents (gantt-chart, finance-report) demonstrate:
 
 ## File Formats
 
-| Document Type | Format | Software Required |
-|---------------|--------|-------------------|
-| Market Analysis | .docx | Microsoft Word or compatible |
-| Finance Report | .xlsx | Microsoft Excel or compatible |
-| Gantt Chart | .xlsx | Microsoft Excel or compatible |
-| Hardware Overview | .pptx | Microsoft PowerPoint or compatible; stored in `hardware/` |
-| Notes and Drafts | .docx | Microsoft Word or compatible |
-| Software Portfolio | .docx | Microsoft Word or compatible |
-| Code Screenshots | .png | Image viewer; stored in `media/` |
-| Demo Videos | .mp4 | Video player; stored in `media/` |
+| Document Type      | Format | Software Required                                         |
+| ------------------ | ------ | --------------------------------------------------------- |
+| Market Analysis    | .docx  | Microsoft Word or compatible                              |
+| Finance Report     | .xlsx  | Microsoft Excel or compatible                             |
+| Gantt Chart        | .xlsx  | Microsoft Excel or compatible                             |
+| Hardware Overview  | .pptx  | Microsoft PowerPoint or compatible; stored in `hardware/` |
+| Notes and Drafts   | .docx  | Microsoft Word or compatible                              |
+| Software Portfolio | .docx  | Microsoft Word or compatible                              |
+| Code Screenshots   | .png   | Image viewer; stored in `media/`                          |
+| Demo Videos        | .mp4   | Video player; stored in `media/`                          |
 
 ## Document Revision History
 
@@ -212,3 +227,7 @@ For complete project information, refer to:
 ## Contact
 
 Questions about documentation content or requests for clarification should be directed through the project repository's issue tracking system or via the contact information provided in the root README.
+
+## Last Reviewed
+
+May 2026

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -2,28 +2,30 @@
 
 This directory documents the physical components, circuit design and assembly process for the NeoPixel LED Cube Project. The hardware consists of a 4×4×4 matrix of addressable RGB LEDs controlled by an Arduino Uno with button inputs, sensor feedback and audio output.
 
+For assembly photos, open [../media/Gallery.md](../media/Gallery.md).
+
 ## Component List
 
 ### Primary Components
 
-| Component | Specification | Quantity | Purpose |
-|-----------|---------------|----------|---------|
-| Arduino Uno | ATmega328P microcontroller | 1 | Main control board |
-| WS2812B LED | 5V addressable RGB LED | 64 | Cube matrix elements |
-| Power Button | SPST momentary switch | 1 | System power control |
-| Mode Button | SPST momentary switch | 1 | Pattern selection |
-| LDR Sensor | Photoresistor (5-10kΩ) | 1 | Ambient light detection |
-| Buzzer | 5V active buzzer | 1 | Audio feedback |
-| Electrolytic Capacitor | 1000µF, 6.3V or higher | 1 | Power supply filtering |
-| Resistor | 10kΩ | 2 | Button pull-up resistors |
-| Resistor | 10kΩ | 1 | LDR voltage divider |
-| Breadboard | Standard 830-point | 1 | Component mounting |
-| Jumper Wires | Male-to-male | ~20 | Circuit connections |
-| Copper Wire | 22-24 AWG solid core | ~5 metres | LED cube structure |
-| Power Supply | 5V DC, 2A minimum | 1 | System power |
-| Power Jack | 2.1mm barrel connector | 1 | Power input |
-| USB Cable | Type A to Type B | 1 | Programming and serial |
-| Enclosure | Custom wooden box | 1 | Housing and protection |
+| Component              | Specification              | Quantity  | Purpose                  |
+| ---------------------- | -------------------------- | --------- | ------------------------ |
+| Arduino Uno            | ATmega328P microcontroller | 1         | Main control board       |
+| WS2812B LED            | 5V addressable RGB LED     | 64        | Cube matrix elements     |
+| Power Button           | SPST momentary switch      | 1         | System power control     |
+| Mode Button            | SPST momentary switch      | 1         | Pattern selection        |
+| LDR Sensor             | Photoresistor (5-10kΩ)     | 1         | Ambient light detection  |
+| Buzzer                 | 5V active buzzer           | 1         | Audio feedback           |
+| Electrolytic Capacitor | 1000µF, 6.3V or higher     | 1         | Power supply filtering   |
+| Resistor               | 10kΩ                       | 2         | Button pull-up resistors |
+| Resistor               | 10kΩ                       | 1         | LDR voltage divider      |
+| Breadboard             | Standard 830-point         | 1         | Component mounting       |
+| Jumper Wires           | Male-to-male               | ~20       | Circuit connections      |
+| Copper Wire            | 22-24 AWG solid core       | ~5 metres | LED cube structure       |
+| Power Supply           | 5V DC, 2A minimum          | 1         | System power             |
+| Power Jack             | 2.1mm barrel connector     | 1         | Power input              |
+| USB Cable              | Type A to Type B           | 1         | Programming and serial   |
+| Enclosure              | Custom wooden box          | 1         | Housing and protection   |
 
 ### Supporting Materials
 
@@ -41,16 +43,19 @@ This directory documents the physical components, circuit design and assembly pr
 The power system uses a 5V DC supply with a minimum 2A rating to safely drive all 64 LEDs. Key design features:
 
 **Voltage Regulation:**
+
 - Arduino Uno powered via barrel jack or USB
 - LEDs receive 5V directly from power supply
 - Shared common ground between Arduino and LED power
 
 **Current Protection:**
+
 - Large electrolytic capacitor (1000µF) across 5V and GND rails
 - Capacitor placed physically close to first LED in chain
 - Smooths voltage spikes during rapid LED colour changes
 
 **Estimated Current Draw:**
+
 - All LEDs at maximum white: ~3.8A (64 LEDs × 60mA)
 - Typical operation: 1.5-2A (mixed colours and brightness)
 - Recommended supply rating: 2A minimum, 3A preferred
@@ -58,11 +63,17 @@ The power system uses a 5V DC supply with a minimum 2A rating to safely drive al
 ### Signal Connections
 
 **NeoPixel Data Line:**
+
 - Single data wire from Arduino pin D6 to first LED in chain
 - Each subsequent LED receives data from previous LED
 - Total of 64 LEDs wired in series
 - Keep data line short to minimise signal degradation
 
 **Button Inputs:**
+
 - Power button connected between D2 and GND
 - Mode button connected between D3 and GND
+
+## Last Reviewed
+
+May 2026

--- a/media/Gallery.md
+++ b/media/Gallery.md
@@ -6,7 +6,7 @@
 https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
 </p>
 
-### 🔧 Build Process
+### Build Process
 
 <table>
   <tr>

--- a/media/README.md
+++ b/media/README.md
@@ -2,65 +2,77 @@
 
 This directory contains all visual and video media assets for the NeoPixel LED Cube Project. These files document the construction process, demonstrate functionality and provide visual reference material for the project.
 
+For a visual-first page with build photos, open [Gallery.md](Gallery.md).
+
 ## File Inventory
 
 ### Photographs
 
 #### cube-build-layer-top-view-1.jpeg
+
 **Description:** Top-down view of LED cube during layer assembly  
 **Purpose:** Documents the structural framework and LED spacing  
 **Usage:** Hardware documentation, construction reference  
 **Resolution:** High-resolution photograph suitable for detailed examination
 
 #### cube-build-lit-view-1.jpeg
+
 **Description:** LED cube lit during build testing  
 **Purpose:** Verifies LED continuity, data flow and early pattern output  
 **Usage:** Build process documentation and testing reference  
 **Resolution:** High-resolution photograph suitable for project documentation
 
 #### cube-frame-complete-angle-1.jpeg
+
 **Description:** Completed cube frame from an angled view  
 **Purpose:** Documents the completed layered structure before final enclosure integration  
 **Usage:** Hardware documentation and construction reference  
 **Resolution:** High-resolution photograph suitable for detailed examination
 
 #### cube-lit-full-bright-front-1.jpeg
+
 **Description:** Completed LED cube illuminated at full brightness  
 **Purpose:** Showcases final appearance and light output  
 **Usage:** Project showcase, documentation header  
 **Resolution:** High-resolution photograph with vibrant colour capture
 
 #### cube-lit-full-bright-front-2.jpeg
+
 **Description:** Alternate front view of the completed cube at full brightness  
 **Purpose:** Provides an additional validation angle for brightness and alignment  
 **Usage:** Project showcase and gallery documentation  
 **Resolution:** High-resolution photograph with vibrant colour capture
 
 #### cube-enclosure-final-setup-1.jpeg
+
 **Description:** Complete assembled project in enclosure  
 **Purpose:** Documents final integrated system  
 **Usage:** Project showcase, completion reference  
 **Resolution:** High-resolution photograph showing complete assembly
 
 #### power-circuit-capacitor-closeup-1.jpeg
+
 **Description:** Detail view of power supply filtering circuit  
 **Purpose:** Documents capacitor placement and connection  
 **Usage:** Hardware assembly reference, circuit verification  
 **Resolution:** Close-up photograph showing component detail
 
 #### power-circuit-connected-to-cube-1.jpeg
+
 **Description:** Power distribution wiring connected to the cube  
 **Purpose:** Documents LED power delivery and wiring organisation  
 **Usage:** Hardware assembly reference and power wiring verification  
 **Resolution:** High-resolution photograph showing wiring detail
 
 #### enclosure-arduino-breadboard-top-1.jpeg
+
 **Description:** Top view of internal component layout  
 **Purpose:** Shows Arduino, breadboard and wiring organisation  
 **Usage:** Assembly reference, cable management guide  
 **Resolution:** High-resolution photograph of internal configuration
 
 #### enclosure-arduino-breadboard-top-2.jpeg
+
 **Description:** Secondary top view of the internal electronics  
 **Purpose:** Highlights cable routing and component placement from another angle  
 **Usage:** Assembly reference and enclosure documentation  
@@ -69,12 +81,14 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 ### Videos
 
 #### neopixel-demo.mp4
+
 **Description:** Full demonstration of all four animation patterns  
 **Purpose:** Visual documentation of system functionality  
 **Duration:** [Duration varies based on actual video]  
 **Format:** MP4 (H.264 video codec, AAC audio codec)  
 **Resolution:** [Resolution varies based on actual video]  
 **Contents:**
+
 - Power-on sequence
 - Colour Wipe pattern demonstration
 - Smooth RGB Fade pattern demonstration
@@ -84,12 +98,14 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 - Brightness adjustment demonstration
 
 #### neopixel-description.mp4
+
 **Description:** Technical walkthrough and project explanation  
 **Purpose:** Provides context and detailed project overview  
 **Duration:** [Duration varies based on actual video]  
 **Format:** MP4 (H.264 video codec, AAC audio codec)  
 **Resolution:** [Resolution varies based on actual video]  
 **Contents:**
+
 - Project objectives and goals
 - Hardware component overview
 - Software architecture explanation
@@ -101,5 +117,11 @@ This directory contains all visual and video media assets for the NeoPixel LED C
 ### Naming Convention
 
 Media files follow a consistent naming pattern like:
+
 ```
 [subject]-[descriptor]-[view/type]-[number].[extension]
+```
+
+## Last Reviewed
+
+May 2026

--- a/software/README.md
+++ b/software/README.md
@@ -2,11 +2,14 @@
 
 This directory contains all software and firmware used in the NeoPixel LED Cube Project. The code is written in C/C++ for the Arduino platform and implements real-time control of 64 addressable RGB LEDs with interactive user input and sensor-based brightness adjustment.
 
+For implementation details in the sketch, open [neopixel_cube/neopixel_cube.ino](neopixel_cube/neopixel_cube.ino).
+
 ## Overview
 
 The software architecture is designed around a state machine model that continuously monitors user inputs, processes sensor data and renders dynamic lighting patterns. The implementation prioritizes modularity, readability and real-time responsiveness.
 
 ## Directory Structure
+
 ```
 software/
 ├── README.md (this file)
@@ -87,6 +90,7 @@ The software requires the following library:
 - **Adafruit NeoPixel** - Official library for controlling WS2812B addressable LEDs
 
 Install via Arduino Library Manager:
+
 ```
 Sketch -> Include Library -> Manage Libraries -> Search "Adafruit NeoPixel"
 ```
@@ -145,18 +149,25 @@ Change the buzzer pin or adjust the duration in the `beep()` function.
 ## Troubleshooting
 
 **LEDs not responding:**
+
 - Verify power supply voltage and current capacity
 - Check data line connection to pin D6
 - Ensure shared ground between Arduino and LED power supply
 
 **Buttons not working:**
+
 - Confirm pull-up resistor configuration
 - Check physical button connections
 - Adjust debounce delay if needed
 
 **Brightness not changing:**
+
 - Verify LDR connection to A0
 - Test LDR functionality with Serial Monitor output
 - Check mapping range in code
 
 For additional details on specific functions and implementation, refer to the inline comments in `neopixel_cube.ino`.
+
+## Last Reviewed
+
+May 2026

--- a/software/neopixel_cube/README.md
+++ b/software/neopixel_cube/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the Arduino sketch that controls the 4×4×4 NeoPixel LED Cube. The firmware implements button-based user interaction, sensor-driven brightness control and four distinct animation patterns.
 
+For full project documentation, see [../../README.md](../../README.md).
+
 ## File Contents
 
 - `neopixel_cube.ino` - Main Arduino sketch
@@ -10,13 +12,13 @@ This directory contains the Arduino sketch that controls the 4×4×4 NeoPixel LE
 
 The following pin assignments are used in the code:
 
-| Pin | Component | Type | Description |
-|-----|-----------|------|-------------|
-| D2 | Power Button | Digital Input | System on/off toggle |
-| D3 | Mode Button | Digital Input | Animation pattern selector |
-| D4 | Buzzer | Digital Output | Audio feedback |
-| D6 | NeoPixel Data | Digital Output | LED data signal |
-| A0 | LDR Sensor | Analogue Input | Ambient light measurement |
+| Pin | Component     | Type           | Description                |
+| --- | ------------- | -------------- | -------------------------- |
+| D2  | Power Button  | Digital Input  | System on/off toggle       |
+| D3  | Mode Button   | Digital Input  | Animation pattern selector |
+| D4  | Buzzer        | Digital Output | Audio feedback             |
+| D6  | NeoPixel Data | Digital Output | LED data signal            |
+| A0  | LDR Sensor    | Analogue Input | Ambient light measurement  |
 
 ## Animation Patterns
 
@@ -25,6 +27,7 @@ The following pin assignments are used in the code:
 Sequentially lights each LED in red, green and blue order. The pattern uses a static state variable to track the current colour phase and LED index. A 50ms interval between LEDs creates a smooth wave effect across the cube.
 
 **Key Features:**
+
 - Non-blocking timing using `millis()`
 - Automatic colour cycling (red -> green -> blue -> red)
 - Complete LED clear between colour transitions
@@ -34,6 +37,7 @@ Sequentially lights each LED in red, green and blue order. The pattern uses a st
 All LEDs fade in and out synchronously through the RGB spectrum. The algorithm incrementally adjusts brightness from 0 to 255, then reverses direction. A 3ms delay between steps ensures smooth visual transitions.
 
 **Key Features:**
+
 - Synchronous fade across all LEDs
 - Smooth brightness ramping
 - Continuous colour cycling
@@ -47,11 +51,13 @@ Simulates realistic flickering flames using a heat simulation algorithm. Each LE
 3. **Sparking** - Random ignition events at the base
 
 **Parameters:**
+
 - `Cooling: 55` - Rate of heat loss
 - `Sparking: 120` - Frequency of new spark generation
 - `SpeedDelay: 15` - Animation update interval
 
 **Colour Mapping:**
+
 - Low heat -> Dark red
 - Medium heat -> Orange/yellow
 - High heat -> Bright yellow/white
@@ -65,6 +71,7 @@ Displays a continuously moving rainbow gradient across the LED array. The colour
 - 170-255: Blue to red
 
 **Key Features:**
+
 - Smooth hue transitions
 - Continuous animation flow
 - Configurable speed (20ms default delay)
@@ -94,11 +101,13 @@ Main execution cycle that runs continuously:
 ## Brightness Control System
 
 The adaptive brightness algorithm uses the following logic:
+
 ```
 Analogue Reading (0-1023) -> Mapped Value (255-20) -> Constrained (20-255)
 ```
 
 **Mapping Details:**
+
 - Lower ambient light (lower LDR value) -> Higher LED brightness
 - Higher ambient light (higher LDR value) -> Lower LED brightness
 - Minimum brightness: 20 (ensures visibility in bright environments)
@@ -137,6 +146,7 @@ Maps a position value (0-255) to a colour on the RGB spectrum. Returns a pointer
 ### Adafruit NeoPixel
 
 **Installation:**
+
 1. Open Arduino IDE
 2. Navigate to Sketch -> Include Library -> Manage Libraries
 3. Search for "Adafruit NeoPixel"
@@ -145,6 +155,7 @@ Maps a position value (0-255) to a colour on the RGB spectrum. Returns a pointer
 **Library Configuration:**
 
 The library is initialised with the following parameters:
+
 ```cpp
 Adafruit_NeoPixel strip = Adafruit_NeoPixel(NUM_LEDS, PIN, NEO_GRB + NEO_KHZ800);
 ```
@@ -164,11 +175,16 @@ The code uses several state-tracking variables:
 - `lastModeButtonState` - Previous mode button state for edge detection
 - `modeChanged` - Boolean flag to control serial output of pattern names
 
+## Last Reviewed
+
+May 2026
+
 Additional static variables within pattern functions preserve animation state between loop iterations.
 
 ## Serial Output Format
 
 Debug information is continuously transmitted via serial at 9600 baud:
+
 ```
 Setup complete. Ready.
 System ON - Pattern: Colour Wipe
@@ -197,6 +213,7 @@ The code is optimised for Arduino Uno's limited resources:
 ### Adjusting Brightness Range
 
 Modify the `map()` function parameters:
+
 ```cpp
 int brightness = map(lightValue, 0, 1023, [MIN], [MAX]);
 ```


### PR DESCRIPTION
## Summary
I completed the documentation refresh so the README is cleaner and links to dedicated pages.

## Changes
- Reworked root README navigation and support sections
- Added root FAQ page and linked it from README
- Added and centered embedded demo video in gallery
- Updated markdown files with cross-links and review timestamps
- Kept emoji usage limited to quick navigation only

## How to test
1. Open README on GitHub and confirm the centered embedded video and updated navigation
2. Open FAQ.md and confirm expanded first-person Q&A content
3. Open media/Gallery.md and confirm embedded video and image sections
4. Spot-check docs README files for updated links and May 2026 review markers

## Related issue
Follow-up documentation sync after #7