### PR TITLE
docs: expand faq and replace linktree with portfolio

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2,7 +2,23 @@
 
 ## Can I use this project for coursework?
 
-Yes. I require attribution under [LICENSE.md](LICENSE.md) and the academic use notice.
+Yes. You can use this project for learning and coursework if you provide clear attribution. Please review [LICENSE.md](LICENSE.md) and follow your institution policy on academic integrity.
+
+## What is this project and what does it do?
+
+This is a 4x4x4 NeoPixel LED cube project built with an Arduino Uno. I designed it to run multiple animation modes, react to ambient light with an LDR sensor and provide button-based interaction for power and mode changes.
+
+## What hardware do I need to build the same setup?
+
+I list the full component breakdown in [hardware/README.md](hardware/README.md). At minimum you need an Arduino Uno, 64 WS2812B LEDs, a stable 5V power supply, two buttons, an LDR, a buzzer and basic wiring materials.
+
+## What power supply should I use?
+
+Use a stable 5V supply with enough current headroom. The documentation recommends at least 2A for this setup, and higher current capacity is safer when driving many LEDs at high brightness.
+
+## Where can I see the build photos and demo media?
+
+Use [media/Gallery.md](media/Gallery.md) for a visual walkthrough and embedded demo video. You can also browse file details in [media/README.md](media/README.md).
 
 ## Where can I see all build photos?
 
@@ -16,6 +32,38 @@ The main sketch is here: [software/neopixel_cube/neopixel_cube.ino](software/neo
 
 See [software/README.md](software/README.md) for architecture and function details.
 
+## How do I upload and run the code on my board?
+
+Open the sketch in Arduino IDE, select Arduino Uno, select the correct COM port, compile and upload. I summarized this in [software/README.md](software/README.md).
+
+## Which LED patterns are included right now?
+
+The current build includes Colour Wipe, Smooth RGB Fade, Fire Effect and Rainbow Cycle.
+
+## How does brightness control work?
+
+The LDR sensor reads ambient light and the firmware maps that value to LED brightness. In the current setup, brighter surroundings reduce LED intensity and darker surroundings increase it.
+
+## What do the buttons do?
+
+One button toggles system power and one button cycles patterns. The firmware uses edge detection with debounce handling to avoid repeated accidental triggers.
+
+## Can I monitor values while the cube is running?
+
+Yes. I print runtime diagnostics over serial at 9600 baud, including power state, selected pattern and mapped brightness values.
+
+## The LEDs are not lighting correctly. What should I check first?
+
+Check power wiring first, then verify shared ground between Arduino and LED power, then confirm the data line from Arduino to the first LED. Also confirm your LED order, solder joints and orientation.
+
+## The buttons are not responding consistently. What should I check?
+
+Check button wiring, pull-up or pull-down configuration and physical switch quality. If needed, increase debounce delay slightly in the code.
+
+## Can I use this code with a different LED count or cube size?
+
+Yes. Update the LED count constants, test current draw and validate each pattern with the new geometry.
+
 ## Where is the hardware documentation?
 
 See [hardware/README.md](hardware/README.md) for components and wiring details.
@@ -27,6 +75,14 @@ Yes. Update the LED count, revise power planning and adjust pattern logic for th
 ## Can I add more LED patterns?
 
 Yes. Add a new pattern function and include it in the mode switch in the main loop.
+
+## Can I contribute improvements?
+
+Yes. I welcome improvements through issues and pull requests. Include a clear summary, test notes and screenshots or video when the change affects visuals.
+
+## Where can I find a full project overview in one place?
+
+Start with [README.md](README.md), then use the section links for software, hardware, media and FAQ.
 
 ## How do I ask questions that are not covered here?
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # Project Contact & Links
 
 <p align="center">
-  <a href="https://linktr.ee/zaccess">
-    <img src="https://img.shields.io/badge/Linktree-zaccess-1de9b6?style=for-the-badge&logo=linktree&logoColor=white">
+  <a href="https://isaacadjei.me">
+    <img src="https://img.shields.io/badge/Website-isaacadjei.me-111111?style=for-the-badge&logo=firefox&logoColor=white">
   </a>
   <a href="https://www.linkedin.com/in/isaacadjei">
     <img src="https://img.shields.io/badge/LinkedIn-Isaac_Adjei-0a66c2?style=for-the-badge&logo=linkedin&logoColor=white">
   </a>
   <a href="mailto:offices.isaac@gmail.com">
     <img src="https://img.shields.io/badge/Email-Contact-ff6f61?style=for-the-badge&logo=gmail&logoColor=white">
-  </a>
-  <a href="https://isaacadjei.me">
-    <img src="https://img.shields.io/badge/Portfolio-isaacadjei.me-111111?style=for-the-badge&logo=firefox&logoColor=white">
   </a>
   
 </p>
@@ -360,7 +357,13 @@ For questions, suggestions or collaboration opportunities related to this projec
 
 You can also contact me directly at **contact@zacess.com**.
 
-**Project Status:** Completed  
-**Last Updated:** May 2026
+<p align="center">
+  <b>Project Status:</b> Completed<br>
+  <b>Last Updated:</b> May 2026
+</p>
 
 ---
+
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&height=100&section=footer" />
+</p>


### PR DESCRIPTION
## Summary
I expanded the FAQ with more project context and replaced the Linktree badge in the README with my portfolio site badge.

## Changes
- Replaced top Linktree badge with isaacadjei.me in README
- Expanded FAQ with setup, troubleshooting, operation and contribution questions
- Kept answers concise, practical and aligned to existing project docs

## How to test
1. Open README and verify the first badge links to isaacadjei.me
2. Open FAQ.md and confirm new detailed Q&A entries
3. Confirm existing project links in FAQ resolve correctly

## Related issue
documentation follow-up refresh