### PR TITLE
docs: add tech stack icons and deepen faq

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -36,6 +36,10 @@ See [software/README.md](software/README.md) for architecture and function detai
 
 Open the sketch in Arduino IDE, select Arduino Uno, select the correct COM port, compile and upload. I summarized this in [software/README.md](software/README.md).
 
+## Which Arduino library is required?
+
+The project depends on the Adafruit NeoPixel library. Install it from Arduino Library Manager before compiling.
+
 ## Which LED patterns are included right now?
 
 The current build includes Colour Wipe, Smooth RGB Fade, Fire Effect and Rainbow Cycle.
@@ -52,6 +56,10 @@ One button toggles system power and one button cycles patterns. The firmware use
 
 Yes. I print runtime diagnostics over serial at 9600 baud, including power state, selected pattern and mapped brightness values.
 
+## What baud rate should I use in Serial Monitor?
+
+Use 9600 baud to match the firmware configuration.
+
 ## The LEDs are not lighting correctly. What should I check first?
 
 Check power wiring first, then verify shared ground between Arduino and LED power, then confirm the data line from Arduino to the first LED. Also confirm your LED order, solder joints and orientation.
@@ -63,6 +71,14 @@ Check button wiring, pull-up or pull-down configuration and physical switch qual
 ## Can I use this code with a different LED count or cube size?
 
 Yes. Update the LED count constants, test current draw and validate each pattern with the new geometry.
+
+## Why is my cube dimmer than expected?
+
+Brightness is intentionally adaptive. The LDR can reduce LED output when ambient light is high. Check sensor placement and mapping values if you want a brighter default.
+
+## Why do animations sometimes look slow?
+
+Pattern speed is controlled by delay values and timing logic in each effect. Reducing delay values can make transitions faster, but too little delay can reduce visual smoothness.
 
 ## Where is the hardware documentation?
 
@@ -79,6 +95,10 @@ Yes. Add a new pattern function and include it in the mode switch in the main lo
 ## Can I contribute improvements?
 
 Yes. I welcome improvements through issues and pull requests. Include a clear summary, test notes and screenshots or video when the change affects visuals.
+
+## Which branch workflow should contributors follow?
+
+Use a topic branch from main, use clear type-prefixed commit messages and open a PR with summary, changes and test steps.
 
 ## Where can I find a full project overview in one place?
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
   🔎 •  
   <a href="#1-project-overview">Overview</a> •
   <a href="#2-key-features">Features</a> •
+  <a href="#21-tech-stack">Tech stack</a> •
   <a href="#3-hardware-components">Hardware</a> •
   <a href="#4-software-architecture">Software</a> •
   <a href="#5-build-documentation">Build</a> •
@@ -66,6 +67,22 @@ The project demonstrates practical applications of digital input handling, analo
 - **Audio Feedback System** - Buzzer provides confirmation tones for user interactions
 - **Real-Time Serial Monitoring** - Debug output displays system state, brightness levels and active patterns
 - **Modular Software Design** - Clean, well-documented code structure for easy modification and expansion
+
+### 2.1 Tech Stack
+
+<p align="center">
+  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/arduino/arduino-original.svg" width="65" />
+  <img src="https://techstack-generator.vercel.app/cpp-icon.svg" width="65" />
+  <img src="https://techstack-generator.vercel.app/c-icon.svg" width="65" />
+  <img src="https://techstack-generator.vercel.app/python-icon.svg" width="65" />
+  <img src="https://techstack-generator.vercel.app/github-icon.svg" width="65" />
+  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" width="65" />
+  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" width="65" />
+</p>
+
+<p align="center">
+  Arduino Uno • C/C++ Firmware • Sensor Integration • Serial Debugging • GitHub Workflow
+</p>
 
 ---
 


### PR DESCRIPTION
## Summary
I added a dedicated Tech Stack section in the root README using the same icon style direction from my profile README and expanded the FAQ with more practical project guidance.

## Changes
- Added Tech Stack section with icon row and concise stack summary
- Added quick navigation link to Tech Stack section
- Expanded FAQ with setup, serial, troubleshooting and workflow questions

## How to test
1. Open README and verify the new Tech Stack section and icons render
2. Confirm quick navigation contains Tech stack link
3. Open FAQ and verify the new detailed questions are present

## Related issue
documentation enhancement follow-up