### PR TITLE
docs: fix video embeds and tech stack table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@
 
 ## Project Walkthrough
 
-<p align="center">
 https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
-</p>
 
 # Quick Navigation
 
@@ -70,19 +68,9 @@ The project demonstrates practical applications of digital input handling, analo
 
 ### 2.1 Tech Stack
 
-<p align="center">
-  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/arduino/arduino-original.svg" width="65" />
-  <img src="https://techstack-generator.vercel.app/cpp-icon.svg" width="65" />
-  <img src="https://techstack-generator.vercel.app/c-icon.svg" width="65" />
-  <img src="https://techstack-generator.vercel.app/python-icon.svg" width="65" />
-  <img src="https://techstack-generator.vercel.app/github-icon.svg" width="65" />
-  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" width="65" />
-  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" width="65" />
-</p>
-
-<p align="center">
-  Arduino Uno • C/C++ Firmware • Sensor Integration • Serial Debugging • GitHub Workflow
-</p>
+| <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/arduino/arduino-original.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/c/c-original.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/cpp-icon.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/python-icon.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/github-icon.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" width="65" /> |
+| :----------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------: |
+|                                                   **Arduino**                                                   |                                                    **C**                                                     |                                   **C++**                                    |                                   **Python**                                    |                                                    **Git**                                                     |                                   **GitHub**                                    |                                                     **VS Code**                                                     |
 
 ---
 

--- a/media/Gallery.md
+++ b/media/Gallery.md
@@ -2,9 +2,7 @@
 
 ### Project Demo Video
 
-<p align="center">
 https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
-</p>
 
 ### Build Process
 


### PR DESCRIPTION
## Summary
I fixed video rendering in README and Gallery and restructured the Tech Stack into a clean icon table layout.

## Changes
- Removed HTML wrappers around user-attachments URLs so GitHub can auto-embed videos
- Updated Tech Stack to a profile-style icon table
- Removed the extra descriptive sentence below the Tech Stack icons

## How to test
1. Open README and verify the video appears as an embedded player
2. Open media/Gallery.md and verify the demo video appears as an embedded player
3. Confirm Tech Stack appears as a table with icons and labels only

## Related issue
documentation layout and embed fix