### PR TITLE
docs: add contributing guide templates and setup docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report something that is not working as expected
+title: "fix: "
+labels: bug
+assignees: ""
+---
+
+## What happened
+
+Describe the problem clearly.
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Environment
+
+- Board:
+- Arduino IDE version:
+- Power supply:
+
+## Logs or screenshots
+
+Add serial output, images, or short video if useful.

--- a/.github/ISSUE_TEMPLATE/docs_update.md
+++ b/.github/ISSUE_TEMPLATE/docs_update.md
@@ -1,0 +1,24 @@
+---
+name: Documentation update
+about: Suggest improvements to README, FAQ, or other docs
+title: "docs: "
+labels: documentation
+assignees: ""
+---
+
+## What
+
+Describe what documentation should be changed.
+
+## Why
+
+Explain why the change is needed.
+
+## Acceptance criteria
+
+- [ ] 
+- [ ] 
+
+## Notes
+
+Add links or context that may help.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Thanks for contributing to this project.
+
+## Workflow
+
+1. Create or pick an issue.
+2. Create a branch from `main`.
+3. Make focused changes.
+4. Commit using type-prefixed messages.
+5. Push and open a pull request.
+
+## Branch Naming
+
+- `feature/short-description`
+- `fix/short-description`
+- `docs/short-description`
+- `refactor/short-description`
+
+## Commit Message Format
+
+Use:
+
+`type: short description`
+
+Common types:
+
+- `feat`
+- `fix`
+- `docs`
+- `refactor`
+- `test`
+- `chore`
+
+## Pull Request Checklist
+
+- Title follows `type: short description`
+- Summary explains what changed and why
+- Changes are listed clearly
+- Test steps are included
+- Related issue is linked with `closes #NUMBER` when relevant
+
+## Reporting Issues
+
+Use the issue templates for bug reports or documentation updates.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@
   <img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge">
 </p>
 
+**Docs Hub:** [FAQ](FAQ.md) | [Hardware](hardware/README.md) | [Software](software/README.md) | [Gallery](media/Gallery.md)
+
+## Quick Setup
+
+1. Build the wiring shown in [hardware/README.md](hardware/README.md).
+2. Install Adafruit NeoPixel in Arduino IDE via Library Manager.
+3. Open [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino).
+4. Select board Arduino Uno and choose the correct COM port.
+5. Upload the sketch and open Serial Monitor at 9600 baud.
+
+## Tested Environment
+
+| Item                    | Tested Value             |
+| ----------------------- | ------------------------ |
+| Arduino IDE             | 2.x                      |
+| Board                   | Arduino Uno (ATmega328P) |
+| LED Type                | WS2812B                  |
+| LED Count               | 64                       |
+| Supply Used During Demo | 5V DC, 2A+               |
+| Serial Baud             | 9600                     |
+
 ## Project Walkthrough
 
 https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
@@ -69,8 +90,8 @@ The project demonstrates practical applications of digital input handling, analo
 ### 2.1 Tech Stack
 
 | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/arduino/arduino-original.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/c/c-original.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/cpp-icon.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/python-icon.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/github-icon.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" width="65" /> |
-| :----------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------: |
-|                                                   **Arduino**                                                   |                                                    **C**                                                     |                                   **C++**                                    |                                   **Python**                                    |                                                    **Git**                                                     |                                   **GitHub**                                    |                                                     **VS Code**                                                     |
+| :------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------: |
+|                                               **Arduino**                                                |                                            **C**                                             |                                   **C++**                                    |                                   **Python**                                    |                                             **Git**                                              |                                   **GitHub**                                    |                                              **VS Code**                                               |
 
 ---
 


### PR DESCRIPTION
## Summary
I implemented the full documentation polish set by adding contribution workflow docs, issue templates and clearer top-level setup guidance.

## Changes
- Added CONTRIBUTING guide
- Added bug report and docs update issue templates
- Added docs hub links in README
- Added quick setup section in README
- Added tested environment table in README

## How to test
1. Open README and confirm Docs Hub, Quick Setup and Tested Environment sections
2. Open CONTRIBUTING.md and confirm workflow and commit standards
3. Open new issue on GitHub and verify templates appear

## Related issue
documentation polish