### PR TITLE
docs: simplify readme and add root technical details

### DIFF
--- a/PROJECT_DETAILS.md
+++ b/PROJECT_DETAILS.md
@@ -1,0 +1,138 @@
+# Project Details
+
+This file contains the full technical details for the NeoPixel LED Cube project.
+
+## 1. Project Overview
+
+The NeoPixel LED Cube Project is an interactive 4x4x4 LED display system developed as part of an academic engineering assignment. This adaptive lighting system combines hardware assembly with embedded software to create a functional LED cube that displays multiple dynamic patterns while automatically adjusting brightness based on ambient light.
+
+The system demonstrates practical applications of digital input handling, analog sensing, PWM-based LED control and real-time embedded logic.
+
+## 2. Hardware Architecture
+
+### 2.1 Component List
+
+| Component | Specification | Quantity | Purpose |
+| --- | --- | --- | --- |
+| Arduino Uno | ATmega328P | 1 | Main microcontroller |
+| WS2812B LEDs | 5V addressable RGB | 64 | LED cube matrix |
+| Power Button | Digital momentary switch | 1 | System power toggle |
+| Mode Button | Digital momentary switch | 1 | Pattern selection |
+| LDR Sensor | Analog light sensor | 1 | Ambient brightness detection |
+| Buzzer | 5V active buzzer | 1 | Audio feedback |
+| Electrolytic Capacitor | 1000uF, 6.3V+ | 1 | Power supply smoothing |
+| Breadboard | Standard size | 1 | Component mounting |
+| Power Supply | 5V, 2A+ | 1 | System power |
+| Enclosure | Custom wooden box | 1 | Housing and protection |
+
+### 2.2 Pin Mapping
+
+| Arduino Pin | Component | Function |
+| --- | --- | --- |
+| D2 | Power Button | Digital input |
+| D3 | Mode Button | Digital input |
+| D4 | Buzzer | Digital output |
+| D6 | NeoPixel Data | LED data output |
+| A0 | LDR Sensor | Analog input |
+
+### 2.3 Electrical Notes
+
+- Use a common ground between Arduino and LED power supply.
+- Keep NeoPixel data line short for signal stability.
+- Use a 1000uF capacitor on 5V rail to reduce voltage spikes.
+- Confirm PSU can handle peak current demand from the LED array.
+
+## 3. Software Architecture
+
+### 3.1 Main Runtime Flow
+
+1. Initialize LED strip and peripherals in setup.
+2. Read button states with debounce logic.
+3. Toggle system power and cycle pattern mode based on input.
+4. Read LDR value and map to LED brightness.
+5. Execute active pattern loop.
+6. Print diagnostics to Serial Monitor.
+
+### 3.2 Implemented Animation Modes
+
+- Mode 0: Colour Wipe
+- Mode 1: Smooth RGB Fade
+- Mode 2: Fire Effect
+- Mode 3: Rainbow Cycle
+
+### 3.3 Brightness Control
+
+- Sensor range: 0 to 1023
+- Brightness range: 20 to 255
+- Mapping: inverse relationship between ambient light and LED brightness
+
+### 3.4 Dependencies
+
+- Adafruit NeoPixel library
+
+## 4. Build and Validation
+
+### 4.1 Build Process Summary
+
+- Constructed the 4x4x4 matrix layer by layer.
+- Verified LED continuity during each stage.
+- Integrated components into an enclosure.
+- Tested input handling, brightness adaptation and all patterns.
+
+### 4.2 Validation Checklist
+
+- [x] Power button toggles state correctly
+- [x] Mode button cycles all patterns
+- [x] LDR changes brightness in real time
+- [x] Serial output reports sensor and state values
+- [x] All 64 LEDs respond correctly
+
+## 5. Troubleshooting Guide
+
+### LEDs not responding
+
+- Verify 5V power and ground continuity.
+- Check D6 data line routing to first LED.
+- Confirm NeoPixel library installation.
+
+### Buttons inconsistent
+
+- Recheck wiring and pull-up/pull-down behavior.
+- Adjust debounce delay if needed.
+
+### Brightness not changing
+
+- Verify LDR wiring to A0.
+- Confirm mapped brightness values in serial output.
+
+## 6. Media and Related Docs
+
+- Visual gallery: [media/Gallery.md](media/Gallery.md)
+- Media catalog: [media/README.md](media/README.md)
+- Hardware details: [hardware/README.md](hardware/README.md)
+- Software details: [software/README.md](software/README.md)
+- FAQ: [FAQ.md](FAQ.md)
+
+## 7. Future Enhancements
+
+- Wireless control via BLE or Wi-Fi
+- Audio-reactive patterns
+- Extended 3D animation library
+- Companion mobile control app
+- Additional thermal and reliability monitoring
+
+## 8. License
+
+This project is released under the MIT License. See [LICENSE.md](LICENSE.md).
+
+## 9. Attribution
+
+Lead Developer: Isaac Zac Adjei
+
+Team: NeoPixel Innovators
+
+Repository: https://github.com/zaccesss/neopixel-led-cube
+
+## 10. Last Updated
+
+May 2026

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Project Contact & Links
+# NeoPixel LED Cube
 
 <p align="center">
   <a href="https://isaacadjei.me">
@@ -10,385 +10,67 @@
   <a href="mailto:offices.isaac@gmail.com">
     <img src="https://img.shields.io/badge/Email-Contact-ff6f61?style=for-the-badge&logo=gmail&logoColor=white">
   </a>
-  
-</p>
-<p align="center">
   <img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge">
 </p>
 
-**Docs Hub:** [FAQ](FAQ.md) | [Hardware](hardware/README.md) | [Software](software/README.md) | [Gallery](media/Gallery.md)
-
-## Quick Setup
-
-1. Build the wiring shown in [hardware/README.md](hardware/README.md).
-2. Install Adafruit NeoPixel in Arduino IDE via Library Manager.
-3. Open [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino).
-4. Select board Arduino Uno and choose the correct COM port.
-5. Upload the sketch and open Serial Monitor at 9600 baud.
-
-## Tested Environment
-
-| Item                    | Tested Value             |
-| ----------------------- | ------------------------ |
-| Arduino IDE             | 2.x                      |
-| Board                   | Arduino Uno (ATmega328P) |
-| LED Type                | WS2812B                  |
-| LED Count               | 64                       |
-| Supply Used During Demo | 5V DC, 2A+               |
-| Serial Baud             | 9600                     |
+A 4x4x4 interactive NeoPixel LED cube built on Arduino Uno with multiple animation modes, adaptive brightness via LDR and physical button controls.
 
 ## Project Walkthrough
 
 https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
 
-# Quick Navigation
+## Quick Start
 
-<p align="center">
-  🔎 •  
-  <a href="#1-project-overview">Overview</a> •
-  <a href="#2-key-features">Features</a> •
-  <a href="#21-tech-stack">Tech stack</a> •
-  <a href="#3-hardware-components">Hardware</a> •
-  <a href="#4-software-architecture">Software</a> •
-  <a href="#5-build-documentation">Build</a> •
-  <a href="#6-user-operation">Usage</a> •
-  <a href="#7-technical-specifications">Specs</a> •
-  <a href="#8-serial-monitor-output">Serial output</a> •
-  <a href="#9-demonstration-media">Media</a> •
-  <a href="#10-future-enhancements">Future</a> •
-  <a href="#11-license-and-supporting-links">License and links</a> •
-  <a href="#12-repository-structure">Repo structure</a> •
-  <a href="#contact-and-support">Contact</a> •
-  <a href="FAQ.md">FAQ</a>
-</p>
+1. Build the wiring setup described in [hardware/README.md](hardware/README.md).
+2. Install Adafruit NeoPixel in Arduino IDE through Library Manager.
+3. Open [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino).
+4. Select Arduino Uno and the correct COM port.
+5. Upload and open Serial Monitor at 9600 baud.
 
----
+## Core Features
 
-## 1. Project Overview
+- 64 addressable WS2812B LEDs in 4x4x4 layout
+- Four built-in animations: Colour Wipe, Smooth RGB Fade, Fire Effect, Rainbow Cycle
+- Auto brightness mapping with LDR sensor
+- Real-time serial debug output
+- Power and mode controls through physical buttons
 
-The NeoPixel LED Cube Project is an interactive 4×4×4 LED display system developed as part of an academic engineering assignment. This adaptive lighting system combines hardware assembly with embedded software to create a fully functional LED cube capable of displaying multiple dynamic patterns while automatically adjusting brightness based on ambient light conditions.
-
-The project demonstrates practical applications of digital input handling, analogue sensing, PWM-based LED control and real-time logic in embedded systems. The cube features user-controlled pattern selection, automatic brightness adjustment via an LDR sensor and audio feedback through a buzzer, providing an engaging and responsive visual experience.
-
-**Lead Developer:** Isaac "Zac" Adjei  
-**Team:** NeoPixel Innovators  
-**Platform:** Arduino Uno  
-**LED Count:** 64 WS2812B addressable LEDs
-
----
-
-## 2. Key Features
-
-- **4×4×4 LED Matrix Architecture** - 64 individually addressable WS2812B NeoPixel LEDs arranged in a cubic structure
-- **Four Dynamic Animation Modes** - Colour Wipe, Smooth RGB Fade, Fire Effect and Rainbow Cycle
-- **Adaptive Brightness Control** - LDR sensor automatically adjusts LED intensity based on ambient light
-- **Interactive User Controls** - Physical buttons for power toggle and mode cycling
-- **Audio Feedback System** - Buzzer provides confirmation tones for user interactions
-- **Real-Time Serial Monitoring** - Debug output displays system state, brightness levels and active patterns
-- **Modular Software Design** - Clean, well-documented code structure for easy modification and expansion
-
-### 2.1 Tech Stack
+## Tech Stack
 
 | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/arduino/arduino-original.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/c/c-original.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/cpp-icon.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/python-icon.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" width="65" /> | <img src="https://techstack-generator.vercel.app/github-icon.svg" width="65" /> | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" width="65" /> |
 | :------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------: |
 |                                               **Arduino**                                                |                                            **C**                                             |                                   **C++**                                    |                                   **Python**                                    |                                             **Git**                                              |                                   **GitHub**                                    |                                              **VS Code**                                               |
 
----
-
-## 3. Hardware Components
-
-### 3.1 Component List
-
-| Component              | Specification            | Quantity | Purpose                      |
-| ---------------------- | ------------------------ | -------- | ---------------------------- |
-| Arduino Uno            | ATmega328P               | 1        | Main microcontroller         |
-| WS2812B LEDs           | 5V addressable RGB       | 64       | LED cube matrix              |
-| Power Button           | Digital momentary switch | 1        | System power toggle          |
-| Mode Button            | Digital momentary switch | 1        | Pattern selection            |
-| LDR Sensor             | Analogue light sensor    | 1        | Ambient brightness detection |
-| Buzzer                 | 5V active buzzer         | 1        | Audio feedback               |
-| Electrolytic Capacitor | 1000µF, 6.3V+            | 1        | Power supply smoothing       |
-| Breadboard             | Standard size            | 1        | Component mounting           |
-| Power Supply           | 5V, ≥2A                  | 1        | System power                 |
-| Enclosure              | Custom wooden box        | 1        | Housing and protection       |
-
-### 3.2 Pin Configuration
-
-| Arduino Pin | Component     | Function                 |
-| ----------- | ------------- | ------------------------ |
-| D2          | Power Button  | Digital input (pull-up)  |
-| D3          | Mode Button   | Digital input (pull-up)  |
-| D4          | Buzzer        | Digital output           |
-| D6          | NeoPixel Data | Data output to LED strip |
-| A0          | LDR Sensor    | Analogue input (0-1023)  |
-| 5V          | Power Rail    | Positive supply (+)      |
-| GND         | Ground        | Common ground (-)        |
-
-### 3.3 Circuit Design
-
-The circuit design incorporates several key safety and performance features:
-
-- **Shared Ground Architecture** - All components share a common ground connection with the Arduino to ensure stable signal communication
-- **Power Supply Decoupling** - A large electrolytic capacitor on the 5V rail protects the LEDs from voltage spikes during rapid switching
-- **Current Limiting** - Power supply rated at minimum 2A to safely drive all 64 LEDs at full brightness
-- **Button Debouncing** - Software-based debouncing prevents false triggering from mechanical switch bounce
-- **Signal Integrity** - Short data line from Arduino to first LED minimises signal degradation
-
----
-
-## 4. Software Architecture
-
-### 4.1 Code Structure
-
-The software is organised around a state machine architecture with real-time input processing and pattern rendering:
-
-**Main Components:**
-
-- **Setup Function** - Initialises hardware peripherals, configures pin modes and establishes serial communication
-- **Loop Function** - Continuously polls button states, reads sensor data and executes the active animation pattern
-- **Pattern Functions** - Four independent animation routines with non-blocking timing control
-- **Helper Functions** - Utility routines for LED control, colour conversion and display updates
-
-### 4.2 Animation Patterns
-
-#### Mode 0: Colour Wipe
-
-Sequentially illuminates each LED in a cascading pattern, cycling through red, green and blue. This pattern creates a smooth wave effect across the cube structure.
-
-#### Mode 1: Smooth RGB Fade
-
-All LEDs fade in and out synchronously, transitioning between red, green and blue. The fade effect uses incremental brightness adjustment for smooth colour transitions.
-
-#### Mode 2: Fire Effect
-
-Simulates realistic flickering flames using a heat simulation algorithm. Each LED is assigned a dynamic heat value that determines its colour, ranging from deep red through orange to bright yellow-white.
-
-#### Mode 3: Rainbow Cycle
-
-Displays a moving rainbow gradient across the entire LED array. The colour wheel algorithm ensures smooth hue transitions and continuous animation flow.
-
-### 4.3 Brightness Control System
-
-The adaptive brightness system maps the LDR sensor reading to LED intensity:
-
-- **Sensor Range:** 0-1023 (10-bit analogue reading)
-- **Brightness Range:** 20-255 (8-bit PWM value)
-- **Mapping Logic:** Inverted relationship - brighter ambient light results in dimmer LEDs to reduce eye strain
-- **Update Frequency:** Real-time adjustment on every loop iteration
-- **Minimum Threshold:** 20/255 ensures LEDs remain visible in all lighting conditions
-
-### 4.4 Required Libraries
-
-- **Adafruit NeoPixel** - Provides low-level control interface for WS2812B LED strips
-
----
-
-## 5. Build Documentation
-
-### 5.1 Physical Construction
-
-The LED cube uses a custom copper wire frame structure that provides both mechanical support and electrical connections. The 4×4×4 matrix is built layer by layer, with each layer soldered into place before proceeding to the next.
-
-**Construction Process:**
-
-1. Created a jig to ensure precise LED spacing and alignment
-2. Bent and cut copper wire segments to form the structural framework
-3. Soldered LEDs in series, maintaining proper data line polarity
-4. Stacked and connected layers with vertical wire supports
-5. Verified continuity and tested each layer before final assembly
-
-### 5.2 Enclosure Design
-
-The wooden enclosure houses the Arduino, breadboard and power distribution components while providing a stable platform for the LED cube. The design includes:
-
-- Cable management channels to organise wiring
-- Ventilation space to prevent heat buildup
-- Access ports for USB programming and power input
-- Front-panel mounting positions for control buttons
-
----
-
-## 6. User Operation
-
-### 6.1 Power On/Off
-
-Press the power button (D2) to toggle the system state. The buzzer will emit a confirmation tone and the cube will either illuminate with the default pattern or turn completely off.
-
-### 6.2 Changing Patterns
-
-While the system is powered on, press the mode button (D3) to cycle through the four available animation patterns. The active pattern name is displayed in the serial monitor.
-
-### 6.3 Brightness Adjustment
-
-Brightness adjusts automatically based on ambient light detected by the LDR sensor. No manual intervention is required. Current brightness values are continuously displayed in the serial monitor.
-
----
-
-## 7. Technical Specifications
-
-| Parameter                 | Value                          |
-| ------------------------- | ------------------------------ |
-| LED Type                  | WS2812B (addressable RGB)      |
-| Total LED Count           | 64                             |
-| Matrix Configuration      | 4×4×4 cube                     |
-| Operating Voltage         | 5V DC                          |
-| Maximum Current Draw      | ~3.8A (all LEDs at full white) |
-| Recommended Power Supply  | 5V, ≥2A                        |
-| Microcontroller           | Arduino Uno (ATmega328P)       |
-| Clock Speed               | 16 MHz                         |
-| Serial Baud Rate          | 9600 bps                       |
-| LDR Analogue Resolution   | 10-bit (0-1023)                |
-| LED Brightness Resolution | 8-bit (0-255)                  |
-
----
-
-## 8. Serial Monitor Output
-
-The Arduino continuously transmits diagnostic information via serial communication at 9600 baud. This output includes:
-
-- System power state changes
-- Active animation pattern name
-- Real-time LDR sensor readings
-- Calculated brightness values
-
-**Example Output:**
-
-```
-Setup complete. Ready.
-System ON - Pattern: Colour Wipe
-LDR: 512 | Brightness: 137
-LDR: 498 | Brightness: 144
-Pattern: Smooth RGB Fade
-LDR: 720 | Brightness: 85
-```
-
----
-
-## 9. Demonstration Media
-
-### 9.1 Visual Documentation
-
-The project includes comprehensive visual documentation:
-
-- **cube-build-layer-top-view-1.jpeg** - Construction process showing layer assembly
-- **cube-lit-full-bright-front-1.jpeg** - Completed cube displaying full brightness pattern
-- **power-circuit-capacitor-closeup-1.jpeg** - Detail view of power supply filtering
-- **enclosure-arduino-breadboard-top-1.jpeg** - Internal component layout
-- **cube-enclosure-final-setup-1.jpeg** - Final assembled project
-
-### 9.2 Video Content
-
-- **neopixel-demo.mp4** - Full demonstration of all four animation patterns
-- **neopixel-description.mp4** - Project walkthrough and technical explanation
-
-For build photos and image walkthroughs, open [media/Gallery.md](media/Gallery.md).
-
-For Arduino source code, open [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino).
-
----
-
-## 10. Future Enhancements
-
-Potential improvements and expansions for future development:
-
-- **Wireless Control** - Integration of Bluetooth or Wi-Fi module for remote pattern selection and parameter adjustment
-- **Audio Reactivity** - Addition of microphone sensor to create sound-responsive lighting effects
-- **Extended Pattern Library** - Implementation of additional animation algorithms such as 3D spirals, plane sweeps and particle effects
-- **Mobile Application** - Development of companion smartphone app for advanced control and customisation
-- **Persistence of Vision Effects** - High-speed pattern switching to create complex visual illusions
-- **Temperature Monitoring** - Addition of thermal sensor to prevent LED overheating during extended operation
-
----
-
-## 11. License and Supporting Links
-
-- License text: [LICENSE.md](LICENSE.md)
-- Expanded FAQ: [FAQ.md](FAQ.md)
-- Full image gallery: [media/Gallery.md](media/Gallery.md)
-- Software overview: [software/README.md](software/README.md)
-- Arduino sketch: [software/neopixel_cube/neopixel_cube.ino](software/neopixel_cube/neopixel_cube.ino)
-
-**Lead Developer:** Isaac "Zac" Adjei  
-**Team:** NeoPixel Innovators  
-**Project Repository:** https://github.com/zaccesss/neopixel-led-cube  
-**Dependencies:** Adafruit NeoPixel Library
-
----
-
-## 12. Repository Structure
-
-The project is organised into separate folders for software, hardware, documentation and media so it is easy to navigate and reuse parts of the work.
-
-- **docs/** - [Documentation folder](docs/) - reports, portfolios, planning files and final presentation
-- **hardware/** - [Hardware resources](hardware/) - hardware overview slides and build notes
-- **media/** - [Images and videos](media/) - photos and videos used in reports and the README
-- **software/** - [Arduino code and software docs](software/) - Arduino firmware and supporting documentation
-
-<details>
-<summary><b>Click to expand full directory tree</b></summary>
-
-```text
-neopixel-led-cube/
-│
-├── .gitignore
-├── LICENSE.md
-├── README.md
-│
-├── docs/
-│   ├── README.md
-│   ├── finance-report.xlsx
-│   ├── gantt-chart.xlsx
-│   ├── market-analysis.docx
-│   ├── notes-and-drafts.docx
-│   ├── presentation-final.pptx
-│   ├── software-portfolio.docx
-│   └── software-portfolio-v2.docx
-│
-├── hardware/
-│   ├── README.md
-│   └── hardware-overview.pptx
-│
-├── media/
-│   ├── Gallery.md
-│   ├── README.md
-│   ├── code-screenshot-1.png
-│   ├── code-screenshot-2.png
-│   ├── cube-build-layer-top-view-1.jpeg
-│   ├── cube-build-lit-view-1.jpeg
-│   ├── cube-enclosure-final-setup-1.jpeg
-│   ├── cube-frame-complete-angle-1.jpeg
-│   ├── cube-lit-full-bright-front-1.jpeg
-│   ├── cube-lit-full-bright-front-2.jpeg
-│   ├── enclosure-arduino-breadboard-top-1.jpeg
-│   ├── enclosure-arduino-breadboard-top-2.jpeg
-│   ├── neopixel-demo.mp4
-│   ├── neopixel-description.mp4
-│   ├── power-circuit-capacitor-closeup-1.jpeg
-│   └── power-circuit-connected-to-cube-1.jpeg
-│
-└── software/
-    ├── README.md
-    └── neopixel_cube/
-        ├── README.md
-        └── neopixel_cube.ino
-```
-
-</details>
-
----
+## Documentation Hub
+
+- Full technical documentation: [PROJECT_DETAILS.md](PROJECT_DETAILS.md)
+- Frequently asked questions: [FAQ.md](FAQ.md)
+- Hardware guide: [hardware/README.md](hardware/README.md)
+- Software guide: [software/README.md](software/README.md)
+- Media gallery: [media/Gallery.md](media/Gallery.md)
+- Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Tested Environment
+
+| Item | Tested Value |
+| --- | --- |
+| Arduino IDE | 2.x |
+| Board | Arduino Uno (ATmega328P) |
+| LED Type | WS2812B |
+| LED Count | 64 |
+| Supply Used During Demo | 5V DC, 2A+ |
+| Serial Baud | 9600 |
 
 ## Contact and Support
 
-For questions, suggestions or collaboration opportunities related to this project, I recommend opening an issue in this repository first.
+If you have questions, open an issue in this repository first.
 
-You can also contact me directly at **contact@zacess.com**.
+You can also contact me directly at contact@zacess.com.
 
 <p align="center">
   <b>Project Status:</b> Completed<br>
   <b>Last Updated:</b> May 2026
 </p>
-
----
 
 <p align="center">
   <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&height=100&section=footer" />


### PR DESCRIPTION
## Summary
I reorganized the docs so the root README stays clean and high signal while full technical depth lives in a dedicated root markdown file.

## Changes
- Simplified README to key project information only
- Added PROJECT_DETAILS.md with full technical documentation
- Linked the new details file through the documentation hub

## How to test
1. Open README and confirm it is concise and easier to scan
2. Open PROJECT_DETAILS.md and confirm full technical detail is present
3. Confirm links between README and detailed docs work correctly

## Related issue
documentation structure cleanup