### PR TITLE
docs: polish README and rename PROJECT_DETAILS to TECHNICAL_REFERENCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:7928ca,100:ff0080&height=180&section=header&text=NeoPixel%20LED%20Cube&fontSize=42&fontColor=ffffff&fontAlignY=38&desc=4x4x4%20Interactive%20LED%20Display%20%7C%20Arduino%20%7C%20WS2812B&descAlignY=60&descSize=16" />
+</p>
+
 # NeoPixel LED Cube
 
 <p align="center">
@@ -15,7 +19,9 @@
 
 A 4x4x4 interactive NeoPixel LED cube built on Arduino Uno with multiple animation modes, adaptive brightness via LDR and physical button controls.
 
-## Project Walkthrough
+<h2 align="center">Project Walkthrough</h2>
+
+<p align="center"><em>Click the video below to watch the full demo.</em></p>
 
 https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
 
@@ -43,23 +49,25 @@ https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
 
 ## Documentation Hub
 
-- Full technical documentation: [PROJECT_DETAILS.md](PROJECT_DETAILS.md)
-- Frequently asked questions: [FAQ.md](FAQ.md)
-- Hardware guide: [hardware/README.md](hardware/README.md)
-- Software guide: [software/README.md](software/README.md)
-- Media gallery: [media/Gallery.md](media/Gallery.md)
-- Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+<p align="center">
+  <a href="TECHNICAL_REFERENCE.md">📖 Technical Reference</a> &nbsp;•&nbsp;
+  <a href="FAQ.md">❓ FAQ</a> &nbsp;•&nbsp;
+  <a href="hardware/README.md">🔧 Hardware Guide</a> &nbsp;•&nbsp;
+  <a href="software/README.md">💻 Software Guide</a> &nbsp;•&nbsp;
+  <a href="media/Gallery.md">🖼️ Gallery</a> &nbsp;•&nbsp;
+  <a href="CONTRIBUTING.md">🤝 Contributing</a>
+</p>
 
 ## Tested Environment
 
-| Item | Tested Value |
-| --- | --- |
-| Arduino IDE | 2.x |
-| Board | Arduino Uno (ATmega328P) |
-| LED Type | WS2812B |
-| LED Count | 64 |
-| Supply Used During Demo | 5V DC, 2A+ |
-| Serial Baud | 9600 |
+| Item                    | Tested Value             |
+| ----------------------- | ------------------------ |
+| Arduino IDE             | 2.x                      |
+| Board                   | Arduino Uno (ATmega328P) |
+| LED Type                | WS2812B                  |
+| LED Count               | 64                       |
+| Supply Used During Demo | 5V DC, 2A+               |
+| Serial Baud             | 9600                     |
 
 ## Contact and Support
 

--- a/TECHNICAL_REFERENCE.md
+++ b/TECHNICAL_REFERENCE.md
@@ -1,6 +1,37 @@
-# Project Details
+# Technical Reference — NeoPixel LED Cube
 
-This file contains the full technical details for the NeoPixel LED Cube project.
+Full technical documentation for the NeoPixel LED Cube project. Covers hardware architecture, software design, build validation, troubleshooting and future development notes.
+
+> Back to [README.md](README.md) &nbsp;|&nbsp; [FAQ.md](FAQ.md) &nbsp;|&nbsp; [media/Gallery.md](media/Gallery.md)
+
+---
+
+## Table of Contents
+
+- [1. Project Overview](#1-project-overview)
+- [2. Hardware Architecture](#2-hardware-architecture)
+  - [2.1 Component List](#21-component-list)
+  - [2.2 Pin Mapping](#22-pin-mapping)
+  - [2.3 Electrical Notes](#23-electrical-notes)
+- [3. Software Architecture](#3-software-architecture)
+  - [3.1 Main Runtime Flow](#31-main-runtime-flow)
+  - [3.2 Implemented Animation Modes](#32-implemented-animation-modes)
+  - [3.3 Brightness Control](#33-brightness-control)
+  - [3.4 Dependencies](#34-dependencies)
+- [4. Build and Validation](#4-build-and-validation)
+  - [4.1 Build Process Summary](#41-build-process-summary)
+  - [4.2 Validation Checklist](#42-validation-checklist)
+- [5. Troubleshooting Guide](#5-troubleshooting-guide)
+  - [LEDs not responding](#leds-not-responding)
+  - [Buttons inconsistent](#buttons-inconsistent)
+  - [Brightness not changing](#brightness-not-changing)
+- [6. Media and Related Docs](#6-media-and-related-docs)
+- [7. Future Enhancements](#7-future-enhancements)
+- [8. License](#8-license)
+- [9. Attribution](#9-attribution)
+- [10. Last Updated](#10-last-updated)
+
+---
 
 ## 1. Project Overview
 
@@ -12,28 +43,28 @@ The system demonstrates practical applications of digital input handling, analog
 
 ### 2.1 Component List
 
-| Component | Specification | Quantity | Purpose |
-| --- | --- | --- | --- |
-| Arduino Uno | ATmega328P | 1 | Main microcontroller |
-| WS2812B LEDs | 5V addressable RGB | 64 | LED cube matrix |
-| Power Button | Digital momentary switch | 1 | System power toggle |
-| Mode Button | Digital momentary switch | 1 | Pattern selection |
-| LDR Sensor | Analog light sensor | 1 | Ambient brightness detection |
-| Buzzer | 5V active buzzer | 1 | Audio feedback |
-| Electrolytic Capacitor | 1000uF, 6.3V+ | 1 | Power supply smoothing |
-| Breadboard | Standard size | 1 | Component mounting |
-| Power Supply | 5V, 2A+ | 1 | System power |
-| Enclosure | Custom wooden box | 1 | Housing and protection |
+| Component              | Specification            | Quantity | Purpose                      |
+| ---------------------- | ------------------------ | -------- | ---------------------------- |
+| Arduino Uno            | ATmega328P               | 1        | Main microcontroller         |
+| WS2812B LEDs           | 5V addressable RGB       | 64       | LED cube matrix              |
+| Power Button           | Digital momentary switch | 1        | System power toggle          |
+| Mode Button            | Digital momentary switch | 1        | Pattern selection            |
+| LDR Sensor             | Analog light sensor      | 1        | Ambient brightness detection |
+| Buzzer                 | 5V active buzzer         | 1        | Audio feedback               |
+| Electrolytic Capacitor | 1000uF, 6.3V+            | 1        | Power supply smoothing       |
+| Breadboard             | Standard size            | 1        | Component mounting           |
+| Power Supply           | 5V, 2A+                  | 1        | System power                 |
+| Enclosure              | Custom wooden box        | 1        | Housing and protection       |
 
 ### 2.2 Pin Mapping
 
-| Arduino Pin | Component | Function |
-| --- | --- | --- |
-| D2 | Power Button | Digital input |
-| D3 | Mode Button | Digital input |
-| D4 | Buzzer | Digital output |
-| D6 | NeoPixel Data | LED data output |
-| A0 | LDR Sensor | Analog input |
+| Arduino Pin | Component     | Function        |
+| ----------- | ------------- | --------------- |
+| D2          | Power Button  | Digital input   |
+| D3          | Mode Button   | Digital input   |
+| D4          | Buzzer        | Digital output  |
+| D6          | NeoPixel Data | LED data output |
+| A0          | LDR Sensor    | Analog input    |
 
 ### 2.3 Electrical Notes
 


### PR DESCRIPTION
## Summary
Polish the root README and rename the technical details file for clarity.

## Changes
- Added capsule-render header animation (purple-to-pink gradient wave) to root README
- Centered Documentation Hub links using HTML with emoji icons
- Added descriptive subtitle beneath the Project Walkthrough heading
- Renamed \PROJECT_DETAILS.md\ → \TECHNICAL_REFERENCE.md\ (git mv, history preserved)
- Added detailed nested table of contents to \TECHNICAL_REFERENCE.md\ with anchor links to all sections and subsections
- Added back-navigation breadcrumb at top of \TECHNICAL_REFERENCE.md\

## How to test
- Visit root README on GitHub — confirm purple-to-pink header wave animation appears at top
- Confirm footer wave animation still present at bottom
- Confirm Documentation Hub links are centered and all resolve correctly
- Confirm \TECHNICAL_REFERENCE.md\ TOC anchor links navigate to correct headings

Closes #14