### PR TITLE
fix: correct GitHub username in documentation URL

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -317,6 +317,6 @@ Lead Developer: Isaac Zac Adjei
 
 Team: NeoPixel Innovators
 
-Repository: https://github.com/zaccessss/neopixel-led-cube
+Repository: https://github.com/zaccesss/neopixel-led-cube
 
 Last Updated: May 2026


### PR DESCRIPTION
Fixes zaccessss (4 s) → zaccesss (3 s) in DOCUMENTATION.md.