### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: zaccesss
+buy_me_a_coffee: zaccesss
+patreon: zaccesss


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with GitHub Sponsors, Buy Me a Coffee and Patreon support links. Closes #24.