### PR TITLE
docs: add workflows folder README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+# Workflows
+
+| Workflow | Runs on | What it does |
+| --- | --- | --- |
+| [`markdownlint.yml`](markdownlint.yml) | Push to `main`, every pull request | Lints every markdown file against [`.markdownlint.json`](../../.markdownlint.json) |
+
+Runnable manually via `workflow_dispatch` from the Actions tab.


### PR DESCRIPTION
## Summary

Every .github/workflows/ folder should document what each workflow does. This one was missing it after the markdownlint CI workflow was added in #32.