### PR TITLE
docs: add Zenodo DOI citation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [1.0.2] - 2026-08-12
 
 ### Added
 
 - Community health files, markdown lint configuration and issue and pull request templates
+- CITATION.cff and a Citing This Work section
+- Registered the repository with Zenodo for a permanent, citable DOI
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,9 @@ authors:
   - family-names: Adjei
     given-names: Isaac
     website: https://isaacadjei.me
-version: 1.0.1
-date-released: "2025-01-01"
+version: 1.0.2
+date-released: "2026-08-12"
+doi: 10.5281/zenodo.21903765
 repository-code: https://github.com/zaccesss/neopixel-led-cube
 license: CC-BY-NC-ND-4.0
 type: software

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NeoPixel LED Cube
 
 <p align="center">
-  <a href="https://doi.org/10.5281/zenodo.21903765">
-    <img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21903765-blue?style=for-the-badge">
+  <a href="https://doi.org/10.5281/zenodo.21903764">
+    <img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21903764-blue?style=for-the-badge">
   </a>
 </p>
 
@@ -65,7 +65,7 @@ https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
 ## Citing This Work
 
 > [!NOTE]
-> This repository is registered with Zenodo and has a permanent, citable DOI: [10.5281/zenodo.21903765](https://doi.org/10.5281/zenodo.21903765). See [CITATION.cff](CITATION.cff) for the full citation. The "Cite this repository" option on GitHub can also be used.
+> This repository is registered with Zenodo and has a permanent, citable DOI: [10.5281/zenodo.21903764](https://doi.org/10.5281/zenodo.21903764). See [CITATION.cff](CITATION.cff) for the full citation. The "Cite this repository" option on GitHub can also be used.
 
 ## Contact and Support
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # NeoPixel LED Cube
 
+<p align="center">
+  <a href="https://doi.org/10.5281/zenodo.21903765">
+    <img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21903765-blue?style=for-the-badge">
+  </a>
+</p>
+
 This is a 4x4x4 NeoPixel LED cube built on an Arduino Uno as an academic engineering project. It runs four animated lighting patterns, adapts its brightness to ambient light through an LDR sensor and responds to two physical buttons for power and pattern control.
 
 <h2 align="center">Project Walkthrough</h2>
@@ -55,6 +61,11 @@ https://github.com/user-attachments/assets/58bd4d04-e2ed-466e-9ed1-12fc8279b9ec
 | LED Count                | 64                        |
 | Supply Used During Demo  | 5V DC, 2A+                |
 | Serial Baud              | 9600                      |
+
+## Citing This Work
+
+> [!NOTE]
+> This repository is registered with Zenodo and has a permanent, citable DOI: [10.5281/zenodo.21903765](https://doi.org/10.5281/zenodo.21903765). See [CITATION.cff](CITATION.cff) for the full citation. The "Cite this repository" option on GitHub can also be used.
 
 ## Contact and Support
 


### PR DESCRIPTION
## Summary

Zenodo archived a new release and minted DOI 10.5281/zenodo.21903765, with concept DOI 10.5281/zenodo.21903764. Added a DOI badge, a Citing This Work section and updated CITATION.cff and CHANGELOG.md.

## Related issue

closes #34