### PR TITLE
fix: remove duplicate DOI badge from top of README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.0.3] - 2026-08-12
+
+### Changed
+
+- Badge row rebuilt as flat, left-aligned licence, version and DOI badges
+- DOI badge now uses the Zenodo concept DOI, which always resolves to the latest release
+
 ## [1.0.2] - 2026-08-12
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,9 +5,9 @@ authors:
   - family-names: Adjei
     given-names: Isaac
     website: https://isaacadjei.me
-version: 1.0.2
+version: 1.0.3
 date-released: "2026-08-12"
-doi: 10.5281/zenodo.21903765
+doi: 10.5281/zenodo.21903764
 repository-code: https://github.com/zaccesss/neopixel-led-cube
 license: CC-BY-NC-ND-4.0
 type: software

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # NeoPixel LED Cube
 
-<p align="center">
-  <a href="https://doi.org/10.5281/zenodo.21903764">
-    <img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21903764-blue?style=for-the-badge">
-  </a>
-</p>
-
 This is a 4x4x4 NeoPixel LED cube built on an Arduino Uno as an academic engineering project. It runs four animated lighting patterns, adapts its brightness to ambient light through an LDR sensor and responds to two physical buttons for power and pattern control.
 
 <h2 align="center">Project Walkthrough</h2>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # NeoPixel LED Cube
 
+[![License: CC BY-NC-ND 4.0](https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-1.0.3-blue.svg)](CHANGELOG.md)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21903764-blue.svg)](https://doi.org/10.5281/zenodo.21903764)
+
 This is a 4x4x4 NeoPixel LED cube built on an Arduino Uno as an academic engineering project. It runs four animated lighting patterns, adapts its brightness to ambient light through an LDR sensor and responds to two physical buttons for power and pattern control.
 
 <h2 align="center">Project Walkthrough</h2>


### PR DESCRIPTION
## Summary

Removed the DOI badge from the top of README.md since it duplicated the link already in the Citing This Work section.

## Notes

Follow-up correction to #35.